### PR TITLE
test(typechecker): prune stale reka ledger rows

### DIFF
--- a/tests/_fixtures/compat-documented-differences.json
+++ b/tests/_fixtures/compat-documented-differences.json
@@ -91,20 +91,6 @@
     },
     {
       "project": "reka-ui",
-      "file": "packages/core/src/Editable/EditableInput.vue",
-      "severity": "error",
-      "line": 69,
-      "column": 6,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
       "file": "packages/core/src/Editable/story/EditableChromatic.story.vue",
       "severity": "error",
       "line": 12,
@@ -116,48 +102,6 @@
       },
       "issue": 5722,
       "reason": "vue-tsc applies the Histoire Story layout prop surface differently for this story file; the exact baseline-only row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Listbox/ListboxContent.vue",
-      "severity": "error",
-      "line": 56,
-      "column": 8,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Listbox/ListboxContent.vue",
-      "severity": "error",
-      "line": 57,
-      "column": 8,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Listbox/ListboxFilter.vue",
-      "severity": "error",
-      "line": 110,
-      "column": 6,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
     },
     {
       "project": "reka-ui",
@@ -200,34 +144,6 @@
       },
       "issue": 5722,
       "reason": "vue-tsc applies the Histoire Story layout prop surface differently for this story file; the exact baseline-only row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/PinInput/PinInputInput.vue",
-      "severity": "error",
-      "line": 262,
-      "column": 6,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/PinInput/PinInputInput.vue",
-      "severity": "error",
-      "line": 263,
-      "column": 6,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
     },
     {
       "project": "reka-ui",
@@ -368,76 +284,6 @@
       },
       "issue": 5722,
       "reason": "vue-tsc reports this baseline-only real-project diagnostic while Vize accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/TagsInput/TagsInputInput.vue",
-      "severity": "error",
-      "line": 163,
-      "column": 6,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/TagsInput/TagsInputInput.vue",
-      "severity": "error",
-      "line": 165,
-      "column": 6,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Tree/TreeItem.vue",
-      "severity": "error",
-      "line": 198,
-      "column": 8,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Tree/TreeItem.vue",
-      "severity": "error",
-      "line": 199,
-      "column": 8,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Tree/TreeRoot.vue",
-      "severity": "error",
-      "line": 288,
-      "column": 8,
-      "vize": null,
-      "baseline": {
-        "code": 1117,
-        "message": "An object literal cannot have multiple properties with the same name."
-      },
-      "issue": 5722,
-      "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
     }
   ]
 }

--- a/tests/tooling/typecheck-divergence-report-ledger.test.ts
+++ b/tests/tooling/typecheck-divergence-report-ledger.test.ts
@@ -28,12 +28,15 @@ const duplicateListenerDifference = {
     "Vize intentionally keeps listener directives out of the props literal.",
 };
 
-function writeDocumentedDifferences(fixture: ReturnType<typeof setup>) {
+function writeDocumentedDifferences(
+  fixture: ReturnType<typeof setup>,
+  differences = [duplicateListenerDifference],
+) {
   const ledgerPath = path.join(fixture.fixtureRoot, "documented-differences.json");
   writeJson(ledgerPath, {
     schema: "vize.compatDocumentedDifferences",
     version: 1,
-    differences: [duplicateListenerDifference],
+    differences,
   });
   return ledgerPath;
 }
@@ -61,13 +64,20 @@ test("typecheck divergence report accepts a reproducing documented difference", 
 test("typecheck divergence report rejects a stale documented difference", () => {
   const fixture = setup();
   try {
+    const secondStaleDifference = {
+      ...duplicateListenerDifference,
+      file: "src/Second.vue",
+      line: 4,
+      column: 2,
+    };
     const result = run(fixture, {}, [
       "--documented-differences",
-      writeDocumentedDifferences(fixture),
+      writeDocumentedDifferences(fixture, [duplicateListenerDifference, secondStaleDifference]),
     ]);
     assert.equal(result.status, 1);
     assert.match(result.stderr, /Documented typecheck difference ledger is stale for fixture/);
     assert.match(result.stderr, /src\/App\.vue:3:1/);
+    assert.match(result.stderr, /src\/Second\.vue:4:2/);
     assert.equal(
       fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
       false,

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -1998,14 +1998,18 @@ fn reject_stale_documented_differences(
     if stale.is_empty() {
         return Ok(());
     }
-    let examples = stale
+    let locations = stale
         .iter()
-        .take(3)
-        .map(|difference| format!("{}:{}:{}", difference.file, difference.line, difference.column))
+        .map(|difference| {
+            format!(
+                "{}:{}:{}",
+                difference.file, difference.line, difference.column
+            )
+        })
         .collect::<Vec<_>>()
-        .join(", ");
+        .join("\n- ");
     Err(format!(
-        "Documented typecheck difference ledger is stale for {project_id}: {} of {} entries did not reproduce; remove converged rows from tests/_fixtures/compat-documented-differences.json ({examples})",
+        "Documented typecheck difference ledger is stale for {project_id}: {} of {} entries did not reproduce; remove converged rows from tests/_fixtures/compat-documented-differences.json:\n- {locations}",
         stale.len(),
         expected.len(),
     ))


### PR DESCRIPTION
## Summary
- remove converged Reka UI duplicate-listener rows from the documented typecheck divergence ledger
- list every stale ledger location in the divergence report error so future ratchets are actionable

## Verification
- COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec node --test --test-concurrency=1 tests/tooling/typecheck-divergence-report-ledger.test.ts tests/tooling/compat-ratchet.test.ts
- COREPACK_HOME=/tmp/vize-corepack-release VIZE_TYPECHECK_DIVERGENCE_PROGRESS=1 rust-script tools/commands/fixtures/typecheck-divergence-report.rs --report-dir /tmp/vize-reka-local-report --registry /tmp/vize-reka-registry.json --budget-mode enforce --vize-bin target/ci/vize --vue-tsc-bin tests/node_modules/.bin/vue-tsc
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791448690&installation_model_id=422833&pr_number=5958&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5958&signature=f975c5ec35757b3aee45ae600622e018275d2432ece114cd6e9d71e7eab1fb4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostic reporting so all stale documented differences are shown, each with its file and line location.
  - Reformatted stale-difference output into a clearer, easier-to-scan list.

- **Tests**
  - Expanded validation to cover multiple stale differences in a single report.
  - Updated compatibility records to remove obsolete diagnostic exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->