### PR TITLE
fix(release): decouple typecheck parity evidence

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -49,6 +49,7 @@ on:
         options:
           - enforce
           - record-only
+          - skip
       davinci_dom_corpus_mode:
         description: "Davinci S2 DOM corpus gate handling"
         required: false
@@ -68,7 +69,6 @@ concurrency:
 permissions:
   contents: read
   issues: read
-
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -259,7 +259,7 @@ jobs:
           exit "$glyph_exit_code"
       - name: Enforce typechecker baseline divergence
         id: typecheck_divergence
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && (inputs.typecheck_divergence_mode || 'enforce') != 'skip' }}
         continue-on-error: true
         timeout-minutes: 100
         env:

--- a/legacy-tools/github/release-preflight-bootstrap.mjs
+++ b/legacy-tools/github/release-preflight-bootstrap.mjs
@@ -53,7 +53,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
         typecheck_dependencies_mode: "record-only",
         lint_divergence_mode: "record-only",
         lsp_mode: "record-only",
-        typecheck_divergence_mode: "enforce",
+        typecheck_divergence_mode: "skip",
         davinci_dom_corpus_mode: "record-only",
       },
       expectedRunName: `Real Project Matrix @ ${headSha}`,

--- a/legacy-tools/github/release-preflight-evidence.mjs
+++ b/legacy-tools/github/release-preflight-evidence.mjs
@@ -1,9 +1,9 @@
 import { requiredRealProjectMatrixShardCount } from "./release-preflight-matrix-evidence.mjs";
 
 /**
- * Real Project Matrix is a required release gate again because the
- * typecheck-divergence surface now runs in enforce mode and the release
- * preflight validates every shard artifact before publishing.
+ * Real Project Matrix stays on the release path for shard-level smoke evidence.
+ * Typecheck parity can be skipped by the release bootstrap while the stricter
+ * ratchet stays available on manual and scheduled matrix runs.
  */
 export const requiredReleaseWorkflows = [
   "Check",

--- a/legacy-tools/github/release-preflight-matrix-evidence.mjs
+++ b/legacy-tools/github/release-preflight-matrix-evidence.mjs
@@ -33,6 +33,7 @@ export async function assertRealProjectMatrixReleaseArtifacts({
   readArtifactEntries,
   registry = readDefaultTypecheckRegistry(),
   enforceParity,
+  requireTypecheckArtifacts = true,
 }) {
   if (typeof readArtifactEntries !== "function") {
     throw new Error("Real Project Matrix artifact reader is required");
@@ -61,9 +62,12 @@ export async function assertRealProjectMatrixReleaseArtifacts({
       expectedTypecheckProjects,
       observedTypecheckProjects,
       enforceParity,
+      requireTypecheckArtifacts,
     });
   }
-  assertReleaseTypecheckCoverage(expectedTypecheckProjects, observedTypecheckProjects);
+  if (requireTypecheckArtifacts) {
+    assertReleaseTypecheckCoverage(expectedTypecheckProjects, observedTypecheckProjects);
+  }
 }
 
 function assertRealProjectShardArtifact({
@@ -74,6 +78,7 @@ function assertRealProjectShardArtifact({
   expectedTypecheckProjects,
   observedTypecheckProjects,
   enforceParity,
+  requireTypecheckArtifacts,
 }) {
   const summary = readJsonEntry(entries, "summary.json", artifactName);
   if (
@@ -109,6 +114,7 @@ function assertRealProjectShardArtifact({
     expectedTypecheckProjects,
     observedTypecheckProjects,
     enforceParity,
+    requireTypecheckArtifacts,
   });
 }
 

--- a/legacy-tools/github/release-preflight-typecheck-evidence.mjs
+++ b/legacy-tools/github/release-preflight-typecheck-evidence.mjs
@@ -1,7 +1,7 @@
 import { parseJsonText, readTextEntry, sha256 } from "./release-preflight-artifact-entries.mjs";
 
-// Release evidence must prove exact typecheck parity. Ad hoc callers can still
-// pass `enforceParity: false` when they intentionally inspect a broken artifact.
+// Strict callers can require exact typecheck parity. Release preflight can pass
+// `enforceParity: false` while typechecker parity is tracked as its own ratchet.
 export const releaseTypecheckParityEnforced = true;
 
 export function assertReleaseTypecheckShardArtifacts({
@@ -11,6 +11,7 @@ export function assertReleaseTypecheckShardArtifacts({
   expectedTypecheckProjects,
   observedTypecheckProjects,
   enforceParity = releaseTypecheckParityEnforced,
+  requireTypecheckArtifacts = true,
 }) {
   const divergenceEntries = matchingEntries(
     entries,
@@ -22,7 +23,7 @@ export function assertReleaseTypecheckShardArtifacts({
     /(^|\/)[^/]+-typecheck-dependencies\.json$/,
     `${artifactName} typecheck dependency artifact`,
   );
-  if (divergenceEntries.length !== dependencyEntries.length) {
+  if (requireTypecheckArtifacts && divergenceEntries.length !== dependencyEntries.length) {
     throw new Error(
       `${artifactName} typecheck dependency artifact count ${dependencyEntries.length} does not match divergence artifact count ${divergenceEntries.length}`,
     );

--- a/legacy-tools/github/release-preflight.mjs
+++ b/legacy-tools/github/release-preflight.mjs
@@ -308,6 +308,8 @@ export async function verifyReleasePreflight(env = process.env, { bootstrap = tr
   await assertRealProjectMatrixReleaseArtifacts({
     run: realProjectMatrixRun,
     artifacts,
+    enforceParity: false,
+    requireTypecheckArtifacts: false,
     readArtifactEntries: async (artifact) => downloadArtifactEntries({ artifact, token }),
   });
   verifyGitReleaseTarget(tag, sha, version);

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -69,7 +69,7 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     required: false,
     default: "enforce",
     type: "choice",
-    options: ["enforce", "record-only"],
+    options: ["enforce", "record-only", "skip"],
   });
   assert.deepEqual(dispatch.inputs?.davinci_dom_corpus_mode, {
     description: "Davinci S2 DOM corpus gate handling",
@@ -184,7 +184,14 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     [divergence, "typecheck_divergence"],
   ] as const) {
     assert.equal(step.id, id);
-    assert.equal(step.if, "${{ !cancelled() }}");
+    if (id === "typecheck_divergence") {
+      assert.equal(
+        step.if,
+        "${{ !cancelled() && (inputs.typecheck_divergence_mode || 'enforce') != 'skip' }}",
+      );
+    } else {
+      assert.equal(step.if, "${{ !cancelled() }}");
+    }
     assert.equal(step["continue-on-error"], true);
   }
   assert.ok(

--- a/tests/tooling/real-project-surface-verdict.test.ts
+++ b/tests/tooling/real-project-surface-verdict.test.ts
@@ -138,3 +138,29 @@ test("workflow surface inputs preserve enforce modes and soften only record-only
     { name: "typecheck-divergence", outcome: "success" },
   ]);
 });
+
+test("workflow surface inputs accept explicitly skipped typecheck divergence", () => {
+  const { result, verdict } = runWorkflowVerdict({
+    VIZE_WAIVER_AUDIT_OUTCOME: "success",
+    TYPECHECK_DEPENDENCIES_MODE: "record-only",
+    VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: "success",
+    CORE_TOOLS_MODE: "record-only",
+    VIZE_CORE_TOOLS_OUTCOME: "success",
+    LSP_MODE: "record-only",
+    VIZE_LSP_OUTCOME: "success",
+    LINT_DIVERGENCE_MODE: "record-only",
+    VIZE_LINT_DIVERGENCE_OUTCOME: "success",
+    VIZE_SYNTAX_HIGHLIGHTER_OUTCOME: "success",
+    VIZE_GLYPH_OUTCOME: "success",
+    TYPECHECK_DIVERGENCE_MODE: "skip",
+    VIZE_TYPECHECK_DIVERGENCE_OUTCOME: "skipped",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(verdict.status, "success");
+  assert.deepEqual(verdict.failedSurfaceNames, []);
+  assert.deepEqual(
+    verdict.surfaces.find((surface: { name: string }) => surface.name === "typecheck-divergence"),
+    { name: "typecheck-divergence", outcome: "success" },
+  );
+});

--- a/tests/tooling/release-preflight-bootstrap-budget.test.ts
+++ b/tests/tooling/release-preflight-bootstrap-budget.test.ts
@@ -29,8 +29,8 @@ test("release gate wait budget covers the full Real Project Matrix release gate"
 
 /**
  * The gate set is the release's critical path, so it is asserted whole. Real
- * Project Matrix is intentionally back because typecheck divergence now enforces
- * exact parity and release preflight validates the shard artifacts.
+ * Project Matrix stays in the release path for real-project smoke evidence,
+ * while typecheck parity remains a separately enforced ratchet.
  */
 test("the release gate set includes Real Project Matrix but not artifact-only smoke gates", () => {
   assert.deepEqual(requiredReleaseWorkflows, [

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -75,7 +75,7 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
           typecheck_dependencies_mode: "record-only",
           lint_divergence_mode: "record-only",
           lsp_mode: "record-only",
-          typecheck_divergence_mode: "enforce",
+          typecheck_divergence_mode: "skip",
           davinci_dom_corpus_mode: "record-only",
         },
         expectedRunName: `Real Project Matrix @ ${releaseSha}`,

--- a/tests/tooling/release-preflight-matrix-evidence.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence.test.ts
@@ -209,6 +209,52 @@ test("release preflight can explicitly waive typecheck parity for ad hoc artifac
   assert.match(warnings[0], /must not be record-only/);
 });
 
+test("release preflight can treat typecheck divergence artifacts as optional", async () => {
+  const run = successfulReleaseRun("Real Project Matrix", 516);
+
+  await assert.doesNotReject(() =>
+    assertRealProjectMatrixReleaseArtifacts({
+      run,
+      artifacts: realProjectArtifacts(run),
+      registry: typecheckRegistry(["fixture-0"]),
+      enforceParity: false,
+      requireTypecheckArtifacts: false,
+      readArtifactEntries: async (artifact) => {
+        const entries = shardEntries(Number(artifact.name.split("-").pop()), {
+          typecheckProject: artifact.name === "real-project-matrix-0" ? "fixture-0" : null,
+        });
+        for (const entryName of Object.keys(entries)) {
+          if (entryName.endsWith("-typecheck-divergence.json")) delete entries[entryName];
+        }
+        return entries;
+      },
+    }),
+  );
+});
+
+test("release preflight still binds present optional typecheck evidence", async () => {
+  const run = successfulReleaseRun("Real Project Matrix", 518);
+  await assert.rejects(
+    assertRealProjectMatrixReleaseArtifacts({
+      run,
+      artifacts: realProjectArtifacts(run),
+      registry: typecheckRegistry(),
+      enforceParity: false,
+      requireTypecheckArtifacts: false,
+      readArtifactEntries: async (artifact) => {
+        const entries = shardEntries(Number(artifact.name.split("-").pop()));
+        if (artifact.name === "real-project-matrix-0") {
+          mutateDivergence(entries, (artifact) => {
+            artifact.evidence.commitSha = "c".repeat(40);
+          });
+        }
+        return entries;
+      },
+    }),
+    /not bound to/,
+  );
+});
+
 test("release preflight still rejects unbound typecheck evidence while parity is waived", async () => {
   const run = successfulReleaseRun("Real Project Matrix", 517);
   await assert.rejects(

--- a/tests/tooling/release-preflight-runner-typecheck-policy.test.ts
+++ b/tests/tooling/release-preflight-runner-typecheck-policy.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+import { repoRoot } from "./_helpers/moonbit.ts";
+import { createReleasePreflightVerifyOnlyFixture } from "./support/release-preflight-runner-fixture.ts";
+
+test("verify-only mode accepts shards without optional typecheck divergence artifacts", () => {
+  const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-optional-typecheck-"));
+  try {
+    const fixture = createReleasePreflightVerifyOnlyFixture(tempDir, {
+      mutateShardEntries(_shard, entries) {
+        for (const entryName of Object.keys(entries)) {
+          if (entryName.endsWith("-typecheck-divergence.json")) delete entries[entryName];
+        }
+      },
+    });
+    const result = spawnSync(
+      "rust-script",
+      ["tools/commands/ci/github/release-preflight.rs", "--verify-only"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          ...fixture.env,
+        },
+      },
+    );
+    assert.ifError(result.error);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stdout, new RegExp(`Release preflight passed for ${fixture.tag}`));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -295,7 +295,7 @@ test("bootstrap mode stops waiting when an in-progress gate has failed required 
   }
 });
 
-test("verify-only mode rejects mutation states with observed typecheck drift", () => {
+test("verify-only mode warns without blocking on observed typecheck drift", () => {
   const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-mutation-drift-"));
   try {
     const fixture = createReleasePreflightVerifyOnlyFixture(tempDir, {
@@ -321,8 +321,10 @@ test("verify-only mode rejects mutation states with observed typecheck drift", (
       },
     );
     assert.ifError(result.error);
-    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`.trim());
-    assert.match(result.stderr, /seeded mutation oracle/);
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stdout, /Release typecheck parity not enforced/);
+    assert.match(result.stdout, /seeded mutation oracle/);
+    assert.match(result.stdout, new RegExp(`Release preflight passed for ${fixture.tag}`));
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tools/commands/ci/github/release-preflight.rs
+++ b/tools/commands/ci/github/release-preflight.rs
@@ -202,10 +202,11 @@ fn verify_release_preflight(bootstrap: bool) -> Result<(), String> {
             &format!("actions/runs/{run_id}/artifacts"),
             None,
         )?;
-        matrix_evidence::assert_real_project_matrix_release_artifacts(
+        matrix_evidence::assert_real_project_matrix_release_artifacts_with_typecheck_policy(
             &repo_root()?,
             run,
             &artifacts,
+            matrix_evidence::ReleaseTypecheckEvidencePolicy::Optional,
             |artifact| matrix_evidence::download_artifact_entries(&token, artifact),
         )?;
     }
@@ -531,7 +532,7 @@ fn create_release_gate_dispatch_plans(
                 "typecheck_dependencies_mode": "record-only",
                 "lint_divergence_mode": "record-only",
                 "lsp_mode": "record-only",
-                "typecheck_divergence_mode": "enforce",
+                "typecheck_divergence_mode": "skip",
                 "davinci_dom_corpus_mode": "record-only",
             }),
             expected_run_name: format!("Real Project Matrix @ {head_sha}"),

--- a/tools/commands/fixtures/real-project-surface-verdict.rs
+++ b/tools/commands/fixtures/real-project-surface-verdict.rs
@@ -177,10 +177,9 @@ fn env_value(name: &str) -> String {
 }
 
 fn record_only_verdict(outcome: String, mode: String) -> String {
-    if mode == "record-only" && outcome == "failure" {
-        "success".to_string()
-    } else {
-        outcome
+    match (mode.as_str(), outcome.as_str()) {
+        ("record-only", "failure") | ("skip", "skipped") => "success".to_string(),
+        _ => outcome,
     }
 }
 

--- a/tools/support/release/preflight_matrix_evidence.rs
+++ b/tools/support/release/preflight_matrix_evidence.rs
@@ -19,10 +19,17 @@ const ARTIFACT_MAX_UNCOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
 
 static SCRATCH_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-pub fn assert_real_project_matrix_release_artifacts<F>(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReleaseTypecheckEvidencePolicy {
+    Enforce,
+    Optional,
+}
+
+pub fn assert_real_project_matrix_release_artifacts_with_typecheck_policy<F>(
     repo_root: &Path,
     run: &Value,
     artifacts: &[Value],
+    typecheck_policy: ReleaseTypecheckEvidencePolicy,
     mut read_artifact_entries: F,
 ) -> Result<(), String>
 where
@@ -52,9 +59,14 @@ where
             &entries,
             &expected_typecheck_projects,
             &mut observed_typecheck_projects,
+            typecheck_policy,
         )?;
     }
-    assert_release_typecheck_coverage(&expected_typecheck_projects, &observed_typecheck_projects)
+    if typecheck_policy == ReleaseTypecheckEvidencePolicy::Enforce {
+        assert_release_typecheck_coverage(&expected_typecheck_projects, &observed_typecheck_projects)
+    } else {
+        Ok(())
+    }
 }
 
 pub fn download_artifact_entries(
@@ -289,6 +301,7 @@ fn assert_real_project_shard_artifact(
     entries: &BTreeMap<String, String>,
     expected_typecheck_projects: &BTreeSet<String>,
     observed_typecheck_projects: &mut BTreeMap<String, String>,
+    typecheck_policy: ReleaseTypecheckEvidencePolicy,
 ) -> Result<(), String> {
     let run_head_sha = run_head_sha(run)?;
     let summary = read_json_entry(entries, "summary.json", artifact_name)?;
@@ -330,6 +343,7 @@ fn assert_real_project_shard_artifact(
         entries,
         expected_typecheck_projects,
         observed_typecheck_projects,
+        typecheck_policy,
     )
 }
 
@@ -362,10 +376,13 @@ fn assert_release_typecheck_shard_artifacts(
     entries: &BTreeMap<String, String>,
     expected_typecheck_projects: &BTreeSet<String>,
     observed_typecheck_projects: &mut BTreeMap<String, String>,
+    typecheck_policy: ReleaseTypecheckEvidencePolicy,
 ) -> Result<(), String> {
     let divergence_entries = matching_entries(entries, "-typecheck-divergence.json");
     let dependency_entries = matching_entries(entries, "-typecheck-dependencies.json");
-    if divergence_entries.len() != dependency_entries.len() {
+    if typecheck_policy == ReleaseTypecheckEvidencePolicy::Enforce
+        && divergence_entries.len() != dependency_entries.len()
+    {
         return Err(format!(
             "{artifact_name} typecheck dependency artifact count {} does not match divergence artifact count {}",
             dependency_entries.len(),
@@ -405,6 +422,7 @@ fn assert_release_typecheck_shard_artifacts(
             &divergence,
             dependency,
             dependency_sha256,
+            typecheck_policy,
         )?;
         if !expected_typecheck_projects.contains(project) {
             return Err(format!(
@@ -446,6 +464,7 @@ fn assert_release_typecheck_divergence_artifact(
     divergence: &Value,
     dependency: &Value,
     dependency_sha256: &str,
+    typecheck_policy: ReleaseTypecheckEvidencePolicy,
 ) -> Result<(), String> {
     let run_head_sha = run_head_sha(run)?;
     if string_field(divergence, "schema") != Some("vize.fixtureTypecheckDivergenceRun")
@@ -456,7 +475,11 @@ fn assert_release_typecheck_divergence_artifact(
             "{artifact_name} typecheck divergence artifact is not bound to {run_head_sha}"
         ));
     }
-    assert_release_typecheck_parity(artifact_name, divergence)?;
+    if typecheck_policy == ReleaseTypecheckEvidencePolicy::Enforce {
+        assert_release_typecheck_parity(artifact_name, divergence)?;
+    } else if let Err(error) = assert_release_typecheck_parity(artifact_name, divergence) {
+        println!("::warning title=Release typecheck parity not enforced::{error}");
+    }
     assert_release_dependency_link(artifact_name, divergence, dependency, dependency_sha256)
 }
 


### PR DESCRIPTION
Summary
- keep Real Project Matrix as release evidence while allowing release bootstrap to skip typecheck divergence parity
- preserve the default manual/scheduled typecheck divergence mode as enforce
- keep optional typecheck artifacts bound to the exact release run when present

Tests
- cargo fmt --all --check
- COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec node --test tests/tooling/real-project-surface-verdict.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-runner.test.ts tests/tooling/release-preflight-runner-typecheck-policy.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-bootstrap-budget.test.ts
- COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec vp run source:lengths --check --base-ref origin/main
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791549741&installation_model_id=422833&pr_number=5972&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5972&signature=f1f7a1ddfaaac3e5490beedd43d094bdcdbf23a2beadb080db8bf503bdb7d759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Release validation no longer blocks releases when typecheck evidence is missing or parity differs.
  - Typecheck parity issues now generate warnings during release preflight while remaining enforceable in other workflow runs.
  - Added a `skip` option for typecheck divergence checks.
  - Real-project smoke evidence continues to be validated as part of the release process.

- **Validation**
  - Improved handling and reporting of optional typecheck artifacts and skipped workflow results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->