### PR TITLE
fix(ci): pin real project matrix checkout

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
+          ref: ${{ github.sha }}
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version-file: "package.json"
@@ -103,7 +103,6 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: ./.github/actions/setup-rust-script
-
       - name: Enable package manager shims
         run: corepack enable
 
@@ -318,6 +317,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ github.sha }}
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: ./.github/actions/setup-rust-script

--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -38,7 +38,10 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
 
   const checkout = steps.find((step) => step.uses?.startsWith("actions/checkout@"));
   assert.match(checkout?.uses ?? "", /de0fac2e4500dabe0009e67214ff5f5447ce83dd/);
-  assert.deepEqual(checkout?.with, { "persist-credentials": false });
+  assert.deepEqual(checkout?.with, {
+    "persist-credentials": false,
+    ref: "${{ github.sha }}",
+  });
   assert.ok(steps.some((step) => step.uses?.startsWith("dtolnay/rust-toolchain@")));
   assert.ok(steps.some((step) => step.uses === "./.github/actions/setup-rust-script"));
   assert.ok(steps.some((step) => step.uses === "./.github/actions/setup-rust-sticky-cache"));

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -96,6 +96,17 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     FIXTURE_SHARD_INDEX: "${{ matrix.shard }}",
     FIXTURE_REPORT_DIR: "real-project-results/shard-${{ matrix.shard }}",
   });
+  const corpus = workflow.jobs?.["davinci-dom-corpus"];
+  assert.ok(corpus);
+  for (const checkout of [
+    findStep(job.steps ?? [], "Checkout matrix commit"),
+    findStep(corpus.steps ?? [], "Checkout matrix commit"),
+  ]) {
+    assert.deepEqual(checkout.with, {
+      "persist-credentials": false,
+      ref: "${{ github.sha }}",
+    });
+  }
 });
 
 test("real-project workflow hydrates only its shard and runs every core tool", () => {


### PR DESCRIPTION
## Summary
- Pin Real Project Matrix checkout steps to the workflow run SHA
- Keep manual release evidence stable when a failed release attempt rolls back the tag
- Cover both shard and Davinci corpus checkout steps in the workflow test

## Verification
- COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec node --test tests/tooling/real-project-matrix-workflow.test.ts
- COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec vp run source:lengths --check --base-ref origin/main
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791556611&installation_model_id=422833&pr_number=5973&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5973&signature=e483a6356502c3cbdb003654587d0711a82eeb95442229fe80facaa724a4b280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workflow jobs now consistently check out the commit that triggered the run, improving build and test reliability.
- **Tests**
  - Added coverage to verify the relevant jobs exist and use the expected checkout configuration, including the triggering commit reference and credential settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->