### PR TITLE
fix(davinci): avoid duplicate branch-gap text lowering

### DIFF
--- a/crates/vize_s1_to_s2/src/lower/structural.rs
+++ b/crates/vize_s1_to_s2/src/lower/structural.rs
@@ -283,8 +283,12 @@ fn lower_if_group<'a>(
         },
         &cx.allocator,
     )));
+    let mut next_preserved_gap = 0usize;
     for gap in preserved_gaps {
-        let _next = text::lower_text_run(cx, children, plan, gap, out);
+        if gap < next_preserved_gap {
+            continue;
+        }
+        next_preserved_gap = text::lower_text_run(cx, children, plan, gap, out);
     }
     consumed_until
 }

--- a/crates/vize_s1_to_s2/tests/lowering_battery.rs
+++ b/crates/vize_s1_to_s2/tests/lowering_battery.rs
@@ -173,6 +173,16 @@ fn tokenizer_error_diagnostics_snap_to_utf8_boundary() {
 }
 
 #[test]
+fn branch_gap_text_run_reproducer_lowers_once() {
+    let source = std::str::from_utf8(
+        b"<<<<  <pre f=\"formsu|\">\n      <div v-if=\"ut\">\n</div>    <!--  Tab -->\n      <div v-else-if=\"\\\\\0>",
+    )
+    .expect("reproducer is valid UTF-8");
+
+    assert_sound(source, "s1-lowering-branch-gap-text-run-reproducer");
+}
+
+#[test]
 fn the_battery_aggregates_are_pinned() {
     // The decision-surface census over the whole battery: ops minted,
     // diagnostics raised, provenance records written, scopes tagged.


### PR DESCRIPTION
## Summary
- skip preserved branch-gap text entries already consumed by a contiguous text run
- add a minimized S1 lowering regression for the fuzz reproducer

## Tests
- cargo test -p vize_s1_to_s2 branch_gap_text_run_reproducer_lowers_once -- --nocapture
- cargo +nightly fuzz run --fuzz-dir tests/fuzz s1_lowering /tmp/vize-fuzz-repros/5959/crash-c8289f402f313837e91b25c3e02929aa07753d70 -- -runs=1
- cargo +nightly fuzz run --fuzz-dir tests/fuzz s1_lowering /tmp/vize-fuzz-repros/5969/crash-ed4b9bc2bb606b66f2edb9625a3018309856f3b8 -- -runs=1
- cargo test -p vize_s1_to_s2 --test lowering_battery --test text_pass --test vif_pass -- --nocapture
- cargo fmt --all --check
- COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec vp run source:lengths --check --base-ref origin/main
- git diff --check

Fixes #5959
Fixes #5969

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791560582&installation_model_id=422833&pr_number=5974&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5974&signature=42950cde10cf5e677e9e46032ca8683e17d586499e7f0282d98e23d386790e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping preserved text segments from being lowered more than once, improving output correctness for complex branch-gap content.

* **Tests**
  * Added coverage for an adversarial branch-gap text case to verify sound, single-pass lowering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->