### PR TITLE
fix(release): hydrate pnpm before vscode publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,14 @@ jobs:
           path: ~/.local/share/pnpm/store
           key: ${{ runner.os }}-pnpm-vscode-release-${{ hashFiles('package.json') }}-v1
           restore-keys: ${{ runner.os }}-pnpm-vscode-release-
+      - name: Hydrate pnpm for VS Code extension tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_manager="$(node -p "require('./package.json').packageManager")"
+          corepack enable
+          corepack prepare "$package_manager" --activate
+          corepack pnpm --version
       - name: Download editor extension artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: editor-extensions, path: editor-extension-artifacts }

--- a/tests/tooling/github-workflows-release-vscode-corepack.test.ts
+++ b/tests/tooling/github-workflows-release-vscode-corepack.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+
+test("release VS Code publication hydrates corepack pnpm before publishing", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const publishJob = workflowJobBody(workflow, "release-vscode-extension");
+  const hydrateStepIndex = publishJob.indexOf("name: Hydrate pnpm for VS Code extension tooling");
+  const publishStepIndex = publishJob.indexOf("name: Publish VS Code extension");
+
+  assert.notEqual(hydrateStepIndex, -1, "missing pnpm hydration step");
+  assert.notEqual(publishStepIndex, -1, "missing VS Code publish step");
+  assert.ok(hydrateStepIndex < publishStepIndex);
+  assert.match(
+    publishJob,
+    /package_manager="\$\(node -p "require\('\.\/package\.json'\)\.packageManager"\)"/,
+  );
+  assert.match(publishJob, /corepack enable/);
+  assert.match(publishJob, /corepack prepare "\$package_manager" --activate/);
+  assert.match(publishJob, /corepack pnpm --version/);
+});


### PR DESCRIPTION
## Summary
- hydrate the packageManager-pinned pnpm release runner before VS Code Marketplace publication
- cover the hydrate-before-publish workflow ordering with a focused tooling test

## Verification
- `MOON_HOME=/tmp/vize-release-moonbit-20260909/moonbit MOON_BIN=/tmp/vize-release-moonbit-20260909/moonbit-shims/moon PATH=/tmp/vize-release-moonbit-20260909/moonbit-shims:$PATH COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec node --test tests/tooling/github-workflows-release-publish.test.ts tests/tooling/github-workflows-release-vscode-corepack.test.ts tests/tooling/moonbit-publish-vscode-dlx.test.ts`
- `MOON_HOME=/tmp/vize-release-moonbit-20260909/moonbit MOON_BIN=/tmp/vize-release-moonbit-20260909/moonbit-shims/moon PATH=/tmp/vize-release-moonbit-20260909/moonbit-shims:$PATH COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec vp run source:lengths --check --base-ref origin/main`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791564717&installation_model_id=422833&pr_number=5976&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5976&signature=e6253d3a5e14085035c1cdf67761272f125efcc8d551ecd16020b9b3e24be562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the VS Code extension release process by ensuring the configured package manager is available before publishing.
  - Added verification to confirm package manager setup and availability during releases, helping reduce publishing failures.

- **Tests**
  - Added automated checks to ensure package manager preparation occurs before the VS Code extension is published.
  - Verified that the release workflow activates the configured tooling and confirms it is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->