### PR TITLE
fix(release): harden registry publish gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,7 +572,7 @@ jobs:
     name: Release @vizejs/native to npm
     runs-on: ubuntu-24.04
     needs: [plan-release-platforms, build-native-all, release-preflight]
-    timeout-minutes: 30
+    timeout-minutes: 60
     environment: npm
     permissions: { contents: read, id-token: write }
     steps:

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -59,7 +59,7 @@ test("release workflow jobs cap runtime with explicit timeouts", () => {
     ["build-wasm-package", 30],
     ["build-native-all", 90],
     ["smoke-release-packages", 30],
-    ["release-npm-native", 30],
+    ["release-npm-native", 60],
     ["release-npm-fresco-native", 20],
     ["release-npm-wasm", 30],
     ["release-npm-vite-plugin", 15],

--- a/tests/tooling/moonbit-publish-crates-selected.test.ts
+++ b/tests/tooling/moonbit-publish-crates-selected.test.ts
@@ -73,9 +73,9 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
       /Selected crate publish plan: vize_atelier_jsx, vize_patina/,
     );
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
-      "publish --locked -p vize_atelier_jsx",
+      "publish --locked --no-verify -p vize_atelier_jsx",
       `info --registry crates-io vize_atelier_jsx@${version}`,
-      "publish --locked -p vize_patina",
+      "publish --locked --no-verify -p vize_patina",
       `info --registry crates-io vize_patina@${version}`,
     ]);
 
@@ -96,7 +96,7 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
     assert.equal(selectedDryRun.status, 0, selectedDryRun.stderr);
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
       `info --registry crates-io vize_atelier_jsx@${version}`,
-      "publish --dry-run --locked -p vize_patina",
+      "publish --dry-run --locked --no-verify -p vize_patina",
     ]);
     assert.match(selectedDryRun.stdout, /registry-resolvable frontier vize_patina/i);
 

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -166,9 +166,9 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
 
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     const logLines = fs.readFileSync(cargoLogPath, "utf8").trim().split("\n");
-    assert.match(logLines[0] ?? "", /^publish --locked -p vize_carton$/);
+    assert.match(logLines[0] ?? "", /^publish --locked --no-verify -p vize_carton$/);
     assert.match(logLines[1] ?? "", /^info --registry crates-io vize_carton@/);
-    assert.match(logLines.at(-2) ?? "", /^publish --locked -p vize_fresco$/);
+    assert.match(logLines.at(-2) ?? "", /^publish --locked --no-verify -p vize_fresco$/);
     assert.match(logLines.at(-1) ?? "", /^info --registry crates-io vize_fresco@/);
 
     const runDryRun = (alreadyPublished: string[], extraEnv: Record<string, string> = {}) => {
@@ -187,7 +187,7 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       });
     };
     const expectedFrontier = (crateName: string) =>
-      ["publish", "--dry-run", "--locked", "-p", crateName].join(" ");
+      ["publish", "--dry-run", "--locked", "--no-verify", "-p", crateName].join(" ");
     const expectedInfo = (crateName: string) => `info --registry crates-io ${crateName}@${version}`;
 
     const nonePublished = runDryRun([]);
@@ -339,7 +339,7 @@ test("publish_crates treats a non-zero cargo publish exit as success when the cr
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     assert.match(result.stdout, /already resolvable despite a non-zero cargo publish exit/i);
     const logLines = fs.readFileSync(cargoLogPath, "utf8").trim().split("\n");
-    assert.equal(logLines[0], "publish --locked -p vize_carton");
+    assert.equal(logLines[0], "publish --locked --no-verify -p vize_carton");
     assert.match(logLines[1] ?? "", /^info --registry crates-io vize_carton@/);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -4,6 +4,10 @@
 /// single place. The script is deliberately idempotent: if a crate version is
 /// already published, it skips the publish call and only waits until the crate
 /// becomes resolvable from crates.io index queries.
+///
+/// Cargo's local publish verification cannot topologically satisfy this
+/// workspace's exact-version dev-dependency cycles, so release CI performs
+/// workspace validation separately and this script publishes with `--no-verify`.
 
 /// Ordered list of publishable crates. The order is topological because each
 /// crate can require exact versions of earlier workspace crates.
@@ -241,7 +245,7 @@ async fn run_app() -> Int {
     println("Dry-running registry-resolvable frontier \{frontier} v\{version}...")
     if @process.run(
       "cargo",
-      ["publish", "--dry-run", "--locked", "-p", frontier],
+      ["publish", "--dry-run", "--locked", "--no-verify", "-p", frontier],
     ) != 0 {
       @stdio.stderr.write("Crate publish dry-run failed for \{frontier} v\{version}.\n")
       return 1
@@ -272,7 +276,7 @@ async fn run_app() -> Int {
     while attempt <= max_attempts {
       let (publish_exit, publish_stdout, publish_stderr) = @process.collect_output(
         "cargo",
-        ["publish", "--locked", "-p", crate_name],
+        ["publish", "--locked", "--no-verify", "-p", crate_name],
       )
       if publish_exit == 0 {
         published = true


### PR DESCRIPTION
## Summary
- publish crates with `--no-verify` so exact-version dev-dependency cycles do not block Trusted Publishing uploads
- keep serial registry resolution checks after each crate publish
- extend the native npm publish timeout to absorb slow dist-tag visibility

## Verification
- `corepack pnpm exec node --test tests/tooling/moonbit-publish-crates.test.ts tests/tooling/moonbit-publish-crates-selected.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/release-preflight-workflow.test.ts`
- `corepack pnpm exec vp run source:lengths --check --base-ref origin/main`
- `corepack pnpm exec vp check --fix`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791575572&installation_model_id=422833&pr_number=5979&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5979&signature=868e9939870b11562967a3fd07e45bc6017442e193a39f282c062d4c552c1d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the native package release workflow timeout from 30 to 60 minutes, helping longer releases complete successfully.
  * Updated crate publishing to skip Cargo’s local verification step during standard and dry-run publishing.
  * Workspace validation continues to be handled separately in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->