### PR TITLE
fix(release): sanitize crate manifests for publish

### DIFF
--- a/tests/tooling/moonbit-publish-crates-plan.test.ts
+++ b/tests/tooling/moonbit-publish-crates-plan.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "node:test";
+
+import { repoRoot } from "./_helpers/moonbit.ts";
+import {
+  getBlockedByManualPublishCrates,
+  getManualPublishCrates,
+  getMetadata,
+  getPublishedCrates,
+} from "./support/publish-crates-plan.ts";
+
+test("publish_crates script keeps publishable workspace dependencies ordered", () => {
+  const publishedCrates = getPublishedCrates();
+  const publishOrder = new Map(publishedCrates.map((crateName, index) => [crateName, index]));
+  const packages = new Map(getMetadata().packages.map((pkg) => [pkg.name, pkg]));
+
+  for (const crateName of publishedCrates) {
+    const pkg = packages.get(crateName);
+    assert.ok(pkg, `Missing package metadata for ${crateName}`);
+
+    for (const dependency of pkg.dependencies) {
+      const dependencyOrder = publishOrder.get(dependency.name);
+      const strippedOnPublish = dependency.kind === "dev";
+      if (!packages.has(dependency.name) || strippedOnPublish) continue;
+      assert.ok(
+        dependencyOrder != null,
+        `${crateName} cannot depend on deferred workspace crate ${dependency.name}`,
+      );
+      const crateOrder = publishOrder.get(crateName);
+      assert.ok(crateOrder != null, `Missing publish order for ${crateName}`);
+      assert.ok(
+        dependencyOrder < crateOrder,
+        `${crateName} must be published after ${dependency.name}`,
+      );
+    }
+  }
+});
+
+test("publish_crates exactly partitions every publishable workspace crate", () => {
+  const releaseCrates = [
+    ...getPublishedCrates(),
+    ...getManualPublishCrates(),
+    ...getBlockedByManualPublishCrates(),
+  ];
+  const publishableCrates = getMetadata()
+    .packages.filter((pkg) =>
+      path.relative(repoRoot, pkg.manifest_path).startsWith(`crates${path.sep}`),
+    )
+    .filter((pkg) => pkg.publish === null || pkg.publish.length > 0)
+    .map((pkg) => pkg.name);
+
+  assert.equal(new Set(releaseCrates).size, releaseCrates.length, "release crate lists overlap");
+  assert.deepEqual(releaseCrates.toSorted(), publishableCrates.toSorted());
+});
+
+test("publish_crates defers crates that still need manual crates.io handoff", () => {
+  assert.deepEqual(getManualPublishCrates(), [
+    "vize_croquis_cf",
+    "vize_atelier_jsx",
+    "vize_marquette",
+    "vize_doctor",
+  ]);
+});
+
+test("publish_crates only blocks crates that depend on manual-publish exclusions", () => {
+  assert.deepEqual(getBlockedByManualPublishCrates(), ["vize_canon", "vize_patina"]);
+});

--- a/tests/tooling/moonbit-publish-crates-selected.test.ts
+++ b/tests/tooling/moonbit-publish-crates-selected.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { test } from "node:test";
 
 import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+import { assertPublishManifestIsSanitized } from "./support/fake-cargo-publish.ts";
 import { writeFakeCommand } from "./support/fake-command.ts";
 
 function workspaceVersion(): string {
@@ -23,8 +24,15 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
   const binDir = path.join(tempDir, "bin");
   const cargoLogPath = path.join(tempDir, "cargo.log");
   const curlLogPath = path.join(tempDir, "curl.log");
+  const selectedCrates = ["vize_atelier_jsx", "vize_patina"];
   const version = workspaceVersion();
   assert.ok(version);
+  const manifestSnapshots = new Map(
+    selectedCrates.map((crateName) => {
+      const manifestPath = path.join(repoRoot, "crates", crateName, "Cargo.toml");
+      return [manifestPath, fs.readFileSync(manifestPath, "utf8")] as const;
+    }),
+  );
 
   try {
     fs.mkdirSync(binDir, { recursive: true });
@@ -33,8 +41,10 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
       "cargo",
       [
         "const fs = require('node:fs');",
+        "const path = require('node:path');",
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.CARGO_LOG, args.join(' ') + '\\n');",
+        ...assertPublishManifestIsSanitized,
         "if (['package', 'publish', 'info'].includes(args[0])) process.exit(0);",
         "process.exit(1);",
       ].join("\n"),
@@ -73,9 +83,9 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
       /Selected crate publish plan: vize_atelier_jsx, vize_patina/,
     );
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
-      "publish --locked --no-verify -p vize_atelier_jsx",
+      "publish --allow-dirty --no-verify -p vize_atelier_jsx",
       `info --registry crates-io vize_atelier_jsx@${version}`,
-      "publish --locked --no-verify -p vize_patina",
+      "publish --allow-dirty --no-verify -p vize_patina",
       `info --registry crates-io vize_patina@${version}`,
     ]);
 
@@ -96,8 +106,11 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
     assert.equal(selectedDryRun.status, 0, selectedDryRun.stderr);
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
       `info --registry crates-io vize_atelier_jsx@${version}`,
-      "publish --dry-run --locked --no-verify -p vize_patina",
+      "publish --dry-run --allow-dirty --no-verify -p vize_patina",
     ]);
+    for (const [manifestPath, original] of manifestSnapshots) {
+      assert.equal(fs.readFileSync(manifestPath, "utf8"), original);
+    }
     assert.match(selectedDryRun.stdout, /registry-resolvable frontier vize_patina/i);
 
     for (const invalidArgs of [
@@ -115,6 +128,9 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
       assert.equal(fs.readFileSync(cargoLogPath, "utf8"), "");
     }
   } finally {
+    for (const [manifestPath, original] of manifestSnapshots) {
+      fs.writeFileSync(manifestPath, original);
+    }
     rmSync(tempDir, { recursive: true, force: true });
   }
 });

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -1,111 +1,13 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import fs, { mkdtempSync, rmSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { test } from "node:test";
 
 import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+import { assertPublishManifestIsSanitized } from "./support/fake-cargo-publish.ts";
 import { writeFakeCommand } from "./support/fake-command.ts";
-
-type CargoMetadata = {
-  packages: CargoPackage[];
-};
-
-type CargoPackage = {
-  name: string;
-  dependencies: CargoDependency[];
-  manifest_path: string;
-  publish: string[] | null;
-  version: string;
-};
-
-type CargoDependency = { name: string; kind: string | null; req: string };
-
-function getScriptCrateArray(variableName: string): string[] {
-  const scriptPath = path.join(repoRoot, "tools", "moon", "cmd", "publish_crates", "main.mbt");
-  const script = fs.readFileSync(scriptPath, "utf8");
-  const arrayBody = script.match(
-    new RegExp(
-      `let ${variableName}\\s*:\\s*Array\\[String\\]\\s*=\\s*\\[(?<body>[\\s\\S]*?)\\n\\]`,
-      "m",
-    ),
-  )?.groups?.body;
-
-  assert.ok(arrayBody, `Failed to locate ${variableName} in publish_crates`);
-  return Array.from(arrayBody.matchAll(/"([^"]+)"/g), ([, crateName]) => crateName);
-}
-
-const getPublishedCrates = () => getScriptCrateArray("published_crates");
-const getManualPublishCrates = () => getScriptCrateArray("manual_publish_crates");
-const getBlockedByManualPublishCrates = () =>
-  getScriptCrateArray("blocked_by_manual_publish_crates");
-
-function getMetadata(): CargoMetadata {
-  return JSON.parse(
-    execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-    }),
-  ) as CargoMetadata;
-}
-
-test("publish_crates script keeps publishable workspace dependencies ordered", () => {
-  const publishedCrates = getPublishedCrates();
-  const publishOrder = new Map(publishedCrates.map((crateName, index) => [crateName, index]));
-  const packages = new Map(getMetadata().packages.map((pkg) => [pkg.name, pkg]));
-
-  for (const crateName of publishedCrates) {
-    const pkg = packages.get(crateName);
-    assert.ok(pkg, `Missing package metadata for ${crateName}`);
-
-    for (const dependency of pkg.dependencies) {
-      const dependencyOrder = publishOrder.get(dependency.name);
-      const strippedOnPublish = dependency.kind === "dev";
-      if (!packages.has(dependency.name) || strippedOnPublish) continue;
-      assert.ok(
-        dependencyOrder != null,
-        `${crateName} cannot depend on deferred workspace crate ${dependency.name}`,
-      );
-      const crateOrder = publishOrder.get(crateName);
-      assert.ok(crateOrder != null, `Missing publish order for ${crateName}`);
-      assert.ok(
-        dependencyOrder < crateOrder,
-        `${crateName} must be published after ${dependency.name}`,
-      );
-    }
-  }
-});
-
-test("publish_crates exactly partitions every publishable workspace crate", () => {
-  const releaseCrates = [
-    ...getPublishedCrates(),
-    ...getManualPublishCrates(),
-    ...getBlockedByManualPublishCrates(),
-  ];
-  const publishableCrates = getMetadata()
-    .packages.filter((pkg) =>
-      path.relative(repoRoot, pkg.manifest_path).startsWith(`crates${path.sep}`),
-    )
-    .filter((pkg) => pkg.publish === null || pkg.publish.length > 0)
-    .map((pkg) => pkg.name);
-
-  assert.equal(new Set(releaseCrates).size, releaseCrates.length, "release crate lists overlap");
-  assert.deepEqual(releaseCrates.toSorted(), publishableCrates.toSorted());
-});
-
-test("publish_crates defers crates that still need manual crates.io handoff", () => {
-  assert.deepEqual(getManualPublishCrates(), [
-    "vize_croquis_cf",
-    "vize_atelier_jsx",
-    "vize_marquette",
-    "vize_doctor",
-  ]);
-});
-
-test("publish_crates only blocks crates that depend on manual-publish exclusions", () => {
-  assert.deepEqual(getBlockedByManualPublishCrates(), ["vize_canon", "vize_patina"]);
-});
+import { getMetadata, getPublishedCrates } from "./support/publish-crates-plan.ts";
 
 test("publish_crates native script covers publish and idempotent dry-run modes", () => {
   const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-publish-crates-"));
@@ -115,6 +17,14 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
   const publishedCrates = getPublishedCrates();
   const version = getMetadata().packages.find((pkg) => pkg.name === publishedCrates[0])?.version;
   assert.ok(version);
+  const manifestSnapshots = new Map(
+    publishedCrates.map((crateName) => {
+      const manifestPath = path.join(repoRoot, "crates", crateName, "Cargo.toml");
+      return [manifestPath, fs.readFileSync(manifestPath, "utf8")] as const;
+    }),
+  );
+  const cargoLockPath = path.join(repoRoot, "Cargo.lock");
+  const originalCargoLock = fs.readFileSync(cargoLockPath, "utf8");
 
   try {
     fs.mkdirSync(binDir, { recursive: true });
@@ -123,9 +33,12 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       "cargo",
       [
         "const fs = require('node:fs');",
+        "const path = require('node:path');",
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.CARGO_LOG, args.join(' ') + '\\n');",
         "const [command] = args;",
+        ...assertPublishManifestIsSanitized,
+        "if (command === 'publish') fs.appendFileSync(path.join(process.cwd(), 'Cargo.lock'), '\\n# fake cargo publish lock mutation\\n');",
         "if (command === 'publish' && args.includes('--dry-run') && process.env.TEST_FAIL_PUBLISH_DRY_RUN) process.exit(1);",
         "const unresolved = (process.env.TEST_UNRESOLVED_CRATES || '').split(',');",
         "if (command === 'info' && unresolved.includes(args.at(-1).split('@')[0])) { console.error('not in registry index'); process.exit(1); }",
@@ -166,9 +79,9 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
 
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     const logLines = fs.readFileSync(cargoLogPath, "utf8").trim().split("\n");
-    assert.match(logLines[0] ?? "", /^publish --locked --no-verify -p vize_carton$/);
+    assert.match(logLines[0] ?? "", /^publish --allow-dirty --no-verify -p vize_carton$/);
     assert.match(logLines[1] ?? "", /^info --registry crates-io vize_carton@/);
-    assert.match(logLines.at(-2) ?? "", /^publish --locked --no-verify -p vize_fresco$/);
+    assert.match(logLines.at(-2) ?? "", /^publish --allow-dirty --no-verify -p vize_fresco$/);
     assert.match(logLines.at(-1) ?? "", /^info --registry crates-io vize_fresco@/);
 
     const runDryRun = (alreadyPublished: string[], extraEnv: Record<string, string> = {}) => {
@@ -187,7 +100,7 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       });
     };
     const expectedFrontier = (crateName: string) =>
-      ["publish", "--dry-run", "--locked", "--no-verify", "-p", crateName].join(" ");
+      ["publish", "--dry-run", "--allow-dirty", "--no-verify", "-p", crateName].join(" ");
     const expectedInfo = (crateName: string) => `info --registry crates-io ${crateName}@${version}`;
 
     const nonePublished = runDryRun([]);
@@ -273,6 +186,10 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       fs.readFileSync(cargoLogPath, "utf8").trim(),
       expectedFrontier(publishedCrates[0]),
     );
+    for (const [manifestPath, original] of manifestSnapshots) {
+      assert.equal(fs.readFileSync(manifestPath, "utf8"), original);
+    }
+    assert.equal(fs.readFileSync(cargoLockPath, "utf8"), originalCargoLock);
     const frontierCurlLog = fs.readFileSync(curlLogPath, "utf8").trim();
     assert.notEqual(frontierCurlLog, "");
     assert.equal(frontierCurlLog.split("\n").length, 1);
@@ -294,6 +211,10 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       assert.equal(fs.readFileSync(curlLogPath, "utf8"), "");
     }
   } finally {
+    for (const [manifestPath, original] of manifestSnapshots) {
+      fs.writeFileSync(manifestPath, original);
+    }
+    fs.writeFileSync(cargoLockPath, originalCargoLock);
     rmSync(tempDir, { recursive: true, force: true });
   }
 });
@@ -310,8 +231,10 @@ test("publish_crates treats a non-zero cargo publish exit as success when the cr
       "cargo",
       [
         "const fs = require('node:fs');",
+        "const path = require('node:path');",
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.CARGO_LOG, args.join(' ') + '\\n');",
+        ...assertPublishManifestIsSanitized,
         "if (args[0] === 'publish' && args.at(-1) === 'vize_carton') process.exit(1);",
         "if (args[0] === 'publish' || args[0] === 'info') process.exit(0);",
         "process.exit(1);",
@@ -339,7 +262,7 @@ test("publish_crates treats a non-zero cargo publish exit as success when the cr
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     assert.match(result.stdout, /already resolvable despite a non-zero cargo publish exit/i);
     const logLines = fs.readFileSync(cargoLogPath, "utf8").trim().split("\n");
-    assert.equal(logLines[0], "publish --locked --no-verify -p vize_carton");
+    assert.equal(logLines[0], "publish --allow-dirty --no-verify -p vize_carton");
     assert.match(logLines[1] ?? "", /^info --registry crates-io vize_carton@/);
   } finally {
     rmSync(tempDir, { recursive: true, force: true });

--- a/tests/tooling/support/fake-cargo-publish.ts
+++ b/tests/tooling/support/fake-cargo-publish.ts
@@ -1,0 +1,10 @@
+export const assertPublishManifestIsSanitized = [
+  "if (args[0] === 'publish') {",
+  "  const crateName = args.at(-1);",
+  "  const manifest = fs.readFileSync(path.join(process.cwd(), 'crates', crateName, 'Cargo.toml'), 'utf8');",
+  "  if (manifest.includes('[dev-dependencies]') || manifest.includes('.dev-dependencies]')) {",
+  "    console.error(`publish manifest for ${crateName} still includes dev-dependencies`);",
+  "    process.exit(2);",
+  "  }",
+  "}",
+];

--- a/tests/tooling/support/publish-crates-plan.ts
+++ b/tests/tooling/support/publish-crates-plan.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "../_helpers/moonbit.ts";
+
+export type CargoMetadata = {
+  packages: CargoPackage[];
+};
+
+export type CargoPackage = {
+  name: string;
+  dependencies: CargoDependency[];
+  manifest_path: string;
+  publish: string[] | null;
+  version: string;
+};
+
+export type CargoDependency = { name: string; kind: string | null; req: string };
+
+export function getScriptCrateArray(variableName: string): string[] {
+  const scriptPath = path.join(repoRoot, "tools", "moon", "cmd", "publish_crates", "main.mbt");
+  const script = fs.readFileSync(scriptPath, "utf8");
+  const arrayBody = script.match(
+    new RegExp(
+      `let ${variableName}\\s*:\\s*Array\\[String\\]\\s*=\\s*\\[(?<body>[\\s\\S]*?)\\n\\]`,
+      "m",
+    ),
+  )?.groups?.body;
+
+  assert.ok(arrayBody, `Failed to locate ${variableName} in publish_crates`);
+  return Array.from(arrayBody.matchAll(/"([^"]+)"/g), ([, crateName]) => crateName);
+}
+
+export const getPublishedCrates = () => getScriptCrateArray("published_crates");
+export const getManualPublishCrates = () => getScriptCrateArray("manual_publish_crates");
+export const getBlockedByManualPublishCrates = () =>
+  getScriptCrateArray("blocked_by_manual_publish_crates");
+
+export function getMetadata(): CargoMetadata {
+  return JSON.parse(
+    execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+  ) as CargoMetadata;
+}

--- a/tools/moon/cmd/publish_crates/config.mbt
+++ b/tools/moon/cmd/publish_crates/config.mbt
@@ -1,0 +1,47 @@
+/// Parses a positive integer from a string and falls back on invalid input.
+fn positive_int_or(value : String, fallback : Int) -> Int {
+  try {
+    let parsed = @string.parse_int(value)
+    if parsed > 0 {
+      parsed
+    } else {
+      fallback
+    }
+  } catch {
+    _ => fallback
+  }
+}
+
+/// Reads a retry-related integer from the environment with a validated default.
+fn env_positive_int(name : String, fallback : Int) -> Int {
+  match @env.get_env_var(name) {
+    Some(value) if value != "" => positive_int_or(value, fallback)
+    _ => fallback
+  }
+}
+
+/// Extracts the workspace package version from the root `Cargo.toml`.
+/// We only need the `[workspace.package]` version line, so a lightweight line
+/// scanner is more predictable than shelling out to another TOML parser.
+fn workspace_version_from_content(content : String) -> String? {
+  let mut section = ""
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
+  for line in lines {
+    let trimmed = line.trim()
+    if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
+      section = trimmed.to_owned()
+      continue
+    }
+    if section == "[workspace.package]" &&
+      trimmed.has_prefix("version = \"") &&
+      trimmed.has_suffix("\"") {
+      return Some(
+        trimmed
+          .to_owned()
+          .replace(old="version = \"", new="")
+          .replace_all(old="\"", new=""),
+      )
+    }
+  }
+  None
+}

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -67,54 +67,6 @@ fn known_release_crates() -> Array[String] {
   crates
 }
 
-/// Parses a positive integer from a string and falls back on invalid input.
-fn positive_int_or(value : String, fallback : Int) -> Int {
-  try {
-    let parsed = @string.parse_int(value)
-    if parsed > 0 {
-      parsed
-    } else {
-      fallback
-    }
-  } catch {
-    _ => fallback
-  }
-}
-
-/// Reads a retry-related integer from the environment with a validated default.
-fn env_positive_int(name : String, fallback : Int) -> Int {
-  match @env.get_env_var(name) {
-    Some(value) if value != "" => positive_int_or(value, fallback)
-    _ => fallback
-  }
-}
-
-/// Extracts the workspace package version from the root `Cargo.toml`.
-/// We only need the `[workspace.package]` version line, so a lightweight line
-/// scanner is more predictable than shelling out to another TOML parser.
-fn workspace_version_from_content(content : String) -> String? {
-  let mut section = ""
-  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
-  for line in lines {
-    let trimmed = line.trim()
-    if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
-      section = trimmed.to_owned()
-      continue
-    }
-    if section == "[workspace.package]" &&
-      trimmed.has_prefix("version = \"") &&
-      trimmed.has_suffix("\"") {
-      return Some(
-        trimmed
-          .to_owned()
-          .replace(old="version = \"", new="")
-          .replace_all(old="\"", new=""),
-      )
-    }
-  }
-  None
-}
-
 /// Main entry point for ordered and rerun-safe crates.io publishing.
 /// Each crate is published serially, retried on transient failure, and then
 /// verified through Cargo resolution before the next dependent crate is
@@ -243,10 +195,22 @@ async fn run_app() -> Int {
       }
     }
     println("Dry-running registry-resolvable frontier \{frontier} v\{version}...")
-    if @process.run(
+    let (manifest_path, original_manifest, original_lockfile) = match stage_publish_manifest(frontier) {
+      Some(staged) => staged
+      None => {
+        @stdio.stderr.write("Failed to prepare publish manifest for \{frontier}\n")
+        return 1
+      }
+    }
+    let dry_run_exit = @process.run(
       "cargo",
-      ["publish", "--dry-run", "--locked", "--no-verify", "-p", frontier],
-    ) != 0 {
+      ["publish", "--dry-run", "--allow-dirty", "--no-verify", "-p", frontier],
+    )
+    if !restore_publish_manifest(manifest_path, original_manifest, original_lockfile) {
+      @stdio.stderr.write("Failed to restore publish manifest for \{frontier}\n")
+      return 1
+    }
+    if dry_run_exit != 0 {
       @stdio.stderr.write("Crate publish dry-run failed for \{frontier} v\{version}.\n")
       return 1
     }
@@ -274,10 +238,21 @@ async fn run_app() -> Int {
     let mut attempt = 1
     let mut published = false
     while attempt <= max_attempts {
+      let (manifest_path, original_manifest, original_lockfile) = match stage_publish_manifest(crate_name) {
+        Some(staged) => staged
+        None => {
+          @stdio.stderr.write("Failed to prepare publish manifest for \{crate_name}\n")
+          return 1
+        }
+      }
       let (publish_exit, publish_stdout, publish_stderr) = @process.collect_output(
         "cargo",
-        ["publish", "--locked", "--no-verify", "-p", crate_name],
+        ["publish", "--allow-dirty", "--no-verify", "-p", crate_name],
       )
+      if !restore_publish_manifest(manifest_path, original_manifest, original_lockfile) {
+        @stdio.stderr.write("Failed to restore publish manifest for \{crate_name}\n")
+        return 1
+      }
       if publish_exit == 0 {
         published = true
         break

--- a/tools/moon/cmd/publish_crates/manifest.mbt
+++ b/tools/moon/cmd/publish_crates/manifest.mbt
@@ -1,0 +1,74 @@
+/// Cargo still resolves dev-dependencies while preparing a package, so each
+/// publish call strips dev-dependency sections from its local manifest and
+/// restores them immediately after Cargo exits. The temporary manifest can make
+/// Cargo refresh the workspace lockfile, so the lockfile is restored too.
+
+/// Writes a text file and converts write failures into a boolean result.
+fn write_string_to_file(path : String, content : String) -> Bool {
+  try {
+    @xfs.write_string_to_file(path, content)
+    true
+  } catch {
+    _ => false
+  }
+}
+
+fn crate_manifest_path(crate_name : String) -> String {
+  @tool.join_path(@tool.join_path("crates", crate_name), "Cargo.toml")
+}
+
+fn is_manifest_section_header(trimmed : String) -> Bool {
+  trimmed.has_prefix("[") && trimmed.has_suffix("]")
+}
+
+fn is_publish_stripped_section(trimmed : String) -> Bool {
+  trimmed == "[dev-dependencies]" ||
+  (trimmed.has_prefix("[target.") && trimmed.has_suffix(".dev-dependencies]"))
+}
+
+fn publish_manifest_without_dev_dependencies(content : String) -> String {
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
+  let kept : Array[String] = []
+  let mut skipping = false
+  for line in lines {
+    let trimmed = line.trim().to_owned()
+    if is_manifest_section_header(trimmed) {
+      skipping = is_publish_stripped_section(trimmed)
+    }
+    if !skipping {
+      kept.push(line)
+    }
+  }
+  let stripped = kept.join("\n")
+  if content.has_suffix("\n") && !stripped.has_suffix("\n") {
+    stripped + "\n"
+  } else {
+    stripped
+  }
+}
+
+fn stage_publish_manifest(crate_name : String) -> (String, String, String)? {
+  let manifest_path = crate_manifest_path(crate_name)
+  let original = match @tool.read_file_to_string(manifest_path) {
+    Some(content) => content
+    None => return None
+  }
+  let original_lockfile = match @tool.read_file_to_string("Cargo.lock") {
+    Some(content) => content
+    None => return None
+  }
+  let publish_manifest = publish_manifest_without_dev_dependencies(original)
+  if publish_manifest != original && !write_string_to_file(manifest_path, publish_manifest) {
+    return None
+  }
+  Some((manifest_path, original, original_lockfile))
+}
+
+fn restore_publish_manifest(
+  manifest_path : String,
+  original_manifest : String,
+  original_lockfile : String,
+) -> Bool {
+  write_string_to_file(manifest_path, original_manifest) &&
+  write_string_to_file("Cargo.lock", original_lockfile)
+}

--- a/tools/moon/cmd/publish_crates/moon.pkg
+++ b/tools/moon/cmd/publish_crates/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/process",
   "moonbitlang/async/stdio",
+  "moonbitlang/x/fs" @xfs,
   "moonbitlang/x/sys",
 }
 


### PR DESCRIPTION
## Summary
- strip crate dev-dependency sections only around `cargo publish` / dry-run, then restore each manifest and `Cargo.lock`
- split publish script helpers and tooling tests so source-length gates stay green
- cover publish-time manifest sanitization for the full crate plan and selected crate handoff path

## Verification
- `env MOON_HOME=/tmp/vize-release-moonbit-20260909/moonbit MOON_BIN=/tmp/vize-release-moonbit-20260909/moonbit-shims/moon PATH=/tmp/vize-release-moonbit-20260909/moonbit-shims:$PATH COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec vp check --fix`
- `env MOON_HOME=/tmp/vize-release-moonbit-20260909/moonbit MOON_BIN=/tmp/vize-release-moonbit-20260909/moonbit-shims/moon PATH=/tmp/vize-release-moonbit-20260909/moonbit-shims:$PATH COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec node --test tests/tooling/moonbit-publish-crates.test.ts tests/tooling/moonbit-publish-crates-selected.test.ts tests/tooling/moonbit-publish-crates-plan.test.ts tests/tooling/release-preflight-workflow.test.ts`
- `env MOON_HOME=/tmp/vize-release-moonbit-20260909/moonbit MOON_BIN=/tmp/vize-release-moonbit-20260909/moonbit-shims/moon PATH=/tmp/vize-release-moonbit-20260909/moonbit-shims:$PATH COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec vp run source:lengths --check --base-ref origin/main`
- `git diff --check`
- fresh clone with the staged patch: `env MOON_HOME=/tmp/vize-release-moonbit-20260909/moonbit MOON_BIN=/tmp/vize-release-moonbit-20260909/moonbit-shims/moon PATH=/tmp/vize-release-moonbit-20260909/moonbit-shims:$PATH COREPACK_HOME=/tmp/vize-corepack-release corepack pnpm exec moon run --target native tools/moon/cmd/publish_crates -- --dry-run`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791580525&installation_model_id=422833&pr_number=5980&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5980&signature=9ccc80215e53c48705dc12f0eafa2bcf9d358dc5f42fe95f0ac3a5c1e8a34f21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved crate publishing by temporarily removing development-only dependencies from published manifests.
  - Restores project manifests and lockfiles after publishing, including when publishing encounters an error.
  - Added configurable handling for publish retries and workspace version detection.

- **Bug Fixes**
  - Ensures crates are published in dependency order.
  - Prevents development dependencies from being included in published crate manifests.
  - Added validation that publishing leaves local project files unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->