### PR TITLE
fix(patina): ignore native scoped-event listeners

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/scoped_event_names.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/scoped_event_names.rs
@@ -13,16 +13,12 @@
 //!
 //! ### Not Recommended
 //! ```vue
-//! <script setup>
-//! defineEmits(['playAudio', 'pauseAudio', 'reloadAudio'])
-//! </script>
+//! <AudioPlayer @playAudio="play" @pauseAudio="pause" @reloadAudio="reload" />
 //! ```
 //!
 //! ### Recommended
 //! ```vue
-//! <script setup>
-//! defineEmits(['audio:play', 'audio:pause', 'audio:reload'])
-//! </script>
+//! <AudioPlayer @audio:play="play" @audio:pause="pause" @audio:reload="reload" />
 //! ```
 
 #![allow(clippy::disallowed_macros)]
@@ -30,7 +26,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{DirectiveNode, ElementNode, ExpressionNode};
+use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/scoped-event-names",
@@ -50,6 +46,19 @@ const COMMON_SUFFIXES: &[&str] = &[
 pub struct ScopedEventNames;
 
 impl ScopedEventNames {
+    /// Whether `element` is a Vue component with an author-owned event surface.
+    ///
+    /// Native elements expose platform event names (`click`, `contextmenu`,
+    /// `keyup`, ...), so they cannot adopt `context:event` names.
+    fn is_component(element: &ElementNode<'_>) -> bool {
+        element.tag_type == ElementType::Component
+            || element
+                .tag
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_uppercase())
+    }
+
     /// Check if an event name could benefit from scoping
     fn could_benefit_from_scope(event_name: &str) -> Option<&'static str> {
         for suffix in COMMON_SUFFIXES {
@@ -82,7 +91,7 @@ impl Rule for ScopedEventNames {
     fn check_directive<'a>(
         &self,
         ctx: &mut LintContext<'a>,
-        _element: &ElementNode<'a>,
+        element: &ElementNode<'a>,
         directive: &DirectiveNode<'a>,
     ) {
         // Only check v-on directives
@@ -90,9 +99,13 @@ impl Rule for ScopedEventNames {
             return;
         }
 
+        if !Self::is_component(element) {
+            return;
+        }
+
         // Get the event name from the argument
         let event_name = match &directive.arg {
-            Some(ExpressionNode::Simple(s)) => s.content,
+            Some(ExpressionNode::Simple(s)) if s.is_static => s.content,
             _ => return,
         };
 
@@ -135,8 +148,7 @@ mod tests {
     #[test]
     fn test_warn_unscoped_event_with_suffix() {
         let linter = create_linter();
-        let result =
-            linter.lint_template(r#"<button @playAudio="handlePlay"></button>"#, "test.vue");
+        let result = linter.lint_template(r#"<AudioPlayer @playAudio="handlePlay" />"#, "test.vue");
         assert_eq!(result.warning_count, 1);
         insta::assert_debug_snapshot!(result.diagnostics);
     }
@@ -145,6 +157,16 @@ mod tests {
     fn test_valid_simple_event() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<button @click="handleClick"></button>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_native_event_with_common_suffix_on_native_element() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<li @contextmenu.prevent="onMenu" @dblclick="onOpen">x</li>"#,
+            "test.vue",
+        );
         assert_eq!(result.warning_count, 0);
     }
 

--- a/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__scoped_event_names__tests__warn_unscoped_event_with_suffix.snap
+++ b/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__scoped_event_names__tests__warn_unscoped_event_with_suffix.snap
@@ -7,8 +7,8 @@ expression: result.diagnostics
         rule_name: "vue/scoped-event-names",
         severity: Warning,
         message: "Consider using scoped event name for better organization",
-        start: 8,
-        end: 31,
+        start: 13,
+        end: 36,
         help: Some(
             "Use scoped event names like 'update:modelValue' instead of generic names",
         ),

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1336,7 +1336,7 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_compon
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	46	croquis	Croquis analysis	old	vize_croquis	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration/self_name.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/scoped_event_names.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/scoped_event_names.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/slot_name_casing.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/this_in_template.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/use_unique_element_ids.rs	51	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -180,7 +180,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     "the Mealie-shaped dynamic slot fixture keeps its natural modified v-on spelling",
   );
   assert.deepEqual(classify("@click.prevent"), { options: 0, event: 1, keys: 0 });
-  assert.equal(spellings.length, 226, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 227, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- limit vue/scoped-event-names to component listeners
- keep native DOM listeners such as @contextmenu.prevent silent
- add a regression test for the native listener false positive

## Verification
- RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_patina scoped_event_names -- --nocapture
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

Fixes #5935

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791607979&installation_model_id=422833&pr_number=5984&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5984&signature=874071f4377a6c8320828803f9da505de6b414b4a14e7fcf312c12b94a13e149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the `vue/scoped-event-names` lint rule to report unscoped event names only on Vue components.
  - Prevented false positives for native HTML elements, including those with common event-name suffixes.
  - The rule now evaluates static event-name bindings more accurately.

- **Documentation**
  - Updated examples to use template event bindings for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->