### PR TITLE
test(canon): cover defineProps template object usage

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
@@ -6,6 +6,7 @@ use vize_carton::cstr;
 
 mod css_v_bind;
 mod define_emits_unused;
+mod define_props_template_object;
 mod template_props_read;
 
 #[test]

--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused/define_props_template_object.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused/define_props_template_object.rs
@@ -1,0 +1,81 @@
+use super::super::{
+    create_project_case_without_node_modules, resolve_test_tsgo_binary,
+    snapshot_project_diagnostics,
+};
+use super::write_no_unused_tsconfig;
+
+#[test]
+fn define_props_result_binding_is_used_when_template_reads_props_object() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "define-props-result-template-props-object-no-unused-locals",
+        &[
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+interface Props {
+  cols?: number
+}
+
+const props = defineProps<Props>()
+const unusedLocal = 1
+</script>
+
+<template>
+  <div>{{ props.cols }}</div>
+</template>
+"#,
+            ),
+            (
+                "src/WithDefaults.vue",
+                r#"<script setup lang="ts">
+interface Props {
+  cols?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  cols: 1,
+})
+const unusedLocal = 1
+</script>
+
+<template>
+  <div :class="[props.cols]">{{ props.cols }}</div>
+</template>
+"#,
+            ),
+        ],
+    );
+    write_no_unused_tsconfig(&project_root);
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    for file in ["src/App.vue", "src/WithDefaults.vue"] {
+        assert!(
+            !has_unused_binding(&snapshot, file, "props"),
+            "{file} should count template `props.*` reads for defineProps, got: {snapshot:#?}"
+        );
+        assert!(
+            has_unused_binding(&snapshot, file, "unusedLocal"),
+            "{file} should still report unrelated TS6133, got: {snapshot:#?}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn has_unused_binding(
+    snapshot: &[(vize_carton::String, Option<u32>, vize_carton::String)],
+    file: &str,
+    binding: &str,
+) -> bool {
+    snapshot.iter().any(|(candidate_file, code, message)| {
+        candidate_file == file && *code == Some(6133) && message.contains(binding)
+    })
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |          1133 |                   787 |               346 |             157 |     373 |            1006 |      657 |           557 |           697 |
 | Linter                     |           356 |                   356 |                 0 |             298 |     298 |             714 |      238 |           387 |           567 |
-| Typechecker                |           923 |                   255 |               668 |             414 |     214 |             869 |      682 |           498 |           712 |
+| Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           499 |           713 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |
 | LSP                        |           301 |                   301 |                 0 |             115 |      47 |             349 |      114 |           174 |           410 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         923 |             527 |      396 |
+| S0               |         925 |             527 |      398 |
 | old AST/parser   |         166 |              37 |      129 |
 | Croquis analysis |         248 |             127 |      121 |
 | raw OXC          |         214 |             178 |       36 |
@@ -161,7 +161,7 @@ Additional source/manifest rows are in the TSV: 331 omitted.
 | `crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs:1`                    | test/dev | S0 8<br>old AST/parser 8<br>Croquis analysis 1    |    17 |
 | `crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs:3`                        | test/dev | S0 8<br>old AST/parser 7<br>Croquis analysis 1    |    16 |
 
-Additional test/dev rows are in the TSV: 195 omitted.
+Additional test/dev rows are in the TSV: 196 omitted.
 
 ### Typechecker content-mapper
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1828,6 +1828,7 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused.rs	5	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/css_v_bind.rs	182	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/define_emits_unused.rs	111	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/define_props_template_object.rs	74	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs	173	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs	7	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs	11	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- add a noUnusedLocals regression for a defineProps result read only as props.* from the template
- cover both plain defineProps and withDefaults(defineProps()) while preserving unrelated TS6133 reporting
- keep the regression split under the no-unused suite so source-length policy and Davinci inventory stay green

Closes #5937

## Tests
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo fmt --all --check
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo test -p vize_canon define_props_result_binding_is_used_when_template_reads_props_object -- --nocapture
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo test -p vize_canon no_unused -- --nocapture
- rust-script tools/commands/ci/source-file-lengths.rs --check --max-lines 350 --limit 5 --base-ref origin/main
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check
- git diff --check
