### PR TITLE
fix(patina): allow musea art custom blocks

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs
@@ -111,7 +111,7 @@ impl Rule for WarnCustomBlock {
         let spans: Vec<(u32, u32)> = descriptor
             .custom_blocks
             .iter()
-            .filter(|block| !is_known_musea_art_block(ctx.filename, block.block_type.as_ref()))
+            .filter(|block| !is_known_musea_art_block(block.block_type.as_ref()))
             .map(|block| (block.loc.tag_start as u32, block.loc.start as u32))
             .collect();
 
@@ -137,8 +137,8 @@ fn is_sfc_filename(filename: &str) -> bool {
     filename.rsplit('.').next() == Some("vue")
 }
 
-fn is_known_musea_art_block(filename: &str, block_type: &str) -> bool {
-    block_type == "art" && filename.ends_with(".art.vue")
+fn is_known_musea_art_block(block_type: &str) -> bool {
+    block_type == "art"
 }
 
 #[cfg(test)]

--- a/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block/tests.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block/tests.rs
@@ -34,10 +34,8 @@ fn rejects_standalone_html_and_other_filenames() {
 
 #[test]
 fn detects_musea_art_files() {
-    assert!(is_known_musea_art_block("Button.art.vue", "art"));
-    assert!(is_known_musea_art_block("catalog/Button.art.vue", "art"));
-    assert!(!is_known_musea_art_block("Button.vue", "art"));
-    assert!(!is_known_musea_art_block("Button.art.vue", "docs"));
+    assert!(is_known_musea_art_block("art"));
+    assert!(!is_known_musea_art_block("docs"));
 }
 
 #[test]
@@ -101,14 +99,13 @@ fn test_musea_art_file_art_block_is_known() {
 }
 
 #[test]
-fn test_art_block_in_regular_sfc_still_warns() {
+fn test_art_block_in_regular_sfc_is_known() {
     let linter = create_linter();
     let result = linter.lint_sfc(
         "<template>\n  <div />\n</template>\n<art>\n  <variant name=\"Default\" />\n</art>\n",
         "Button.vue",
     );
-    assert_eq!(result.warning_count, 1, "got: {:?}", result.diagnostics);
-    assert_eq!(result.diagnostics[0].rule_name, "vue/warn-custom-block");
+    assert_eq!(result.warning_count, 0, "got: {:?}", result.diagnostics);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- treat top-level <art> as a first-party Musea custom block
- keep vue/warn-custom-block warnings for unknown custom blocks
- update the regular .vue regression coverage for Musea art blocks

## Verification
- RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_patina warn_custom_block -- --nocapture
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

Fixes #5936

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791608114&installation_model_id=422833&pr_number=5986&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5986&signature=34a3e1ac18bb61fefcb457a92b9c83a1475adb77f3e1f414e293f196007e861e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vue files using `<art>` blocks are now recognized as supported blocks and no longer incorrectly reported as custom blocks.
  * Custom-block warnings are now limited to genuinely unrecognized block types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->