### PR TITLE
fix(a11y): honor negative tabindex for hidden focusables

### DIFF
--- a/crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs
@@ -123,6 +123,11 @@ fn no_aria_hidden_on_focusable_template() {
             "negative tabindex",
         ),
         (
+            r#"<input readonly tabindex="-1" aria-hidden="true" />"#,
+            0,
+            "negative tabindex removes native input from tab order",
+        ),
+        (
             r#"<div tabindex="x" aria-hidden="true">Focusable</div>"#,
             1,
             "non-numeric tabindex remains focusable",

--- a/crates/vize_patina/src/rules/a11y/markup_helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/markup_helpers.rs
@@ -17,6 +17,13 @@ pub fn is_interactive_markup_element(element: &MarkupElement<'_>) -> bool {
 
 /// Check if a markup facade element is focusable (natively or via tabindex).
 pub fn is_focusable_markup_element(element: &MarkupElement<'_>) -> bool {
+    if let Some(tabindex) = get_static_markup_attribute_value(element, "tabindex") {
+        if let Ok(val) = tabindex.parse::<i32>() {
+            return val >= 0;
+        }
+        return true;
+    }
+
     if (element.is_unqualified_tag_exact("a") || element.is_unqualified_tag_exact("area"))
         && has_named_markup_prop(element, "href")
     {
@@ -29,13 +36,6 @@ pub fn is_focusable_markup_element(element: &MarkupElement<'_>) -> bool {
         || element.is_unqualified_tag_exact("textarea")
         || element.is_unqualified_tag_exact("summary")
     {
-        return true;
-    }
-
-    if let Some(tabindex) = get_static_markup_attribute_value(element, "tabindex") {
-        if let Ok(val) = tabindex.parse::<i32>() {
-            return val >= 0;
-        }
         return true;
     }
 

--- a/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
@@ -132,6 +132,16 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_aria_hidden_on_input_with_negative_tabindex() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<input class="sizer" readonly tabindex="-1" aria-hidden="true" />"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
     fn test_valid_aria_hidden_false_on_button() {
         let linter = create_linter();
         let result =

--- a/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
@@ -1909,17 +1909,6 @@
         "help": "Reorder attributes to follow the recommended order"
       },
       {
-        "ruleId": "a11y/no-aria-hidden-on-focusable",
-        "ruleDocsPath": "docs/content/rules/accessibility.md",
-        "severity": 2,
-        "message": "[vize:a11y/no-aria-hidden-on-focusable] aria-hidden=\"true\" must not be used on focusable elements",
-        "line": 79,
-        "column": 11,
-        "endLine": 86,
-        "endColumn": 12,
-        "help": "Remove aria-hidden=\"true\" or make the element non-focusable with tabindex=\"-1\""
-      },
-      {
         "ruleId": "vue/attribute-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1942,7 +1931,7 @@
         "help": "Reorder attributes to follow the recommended order"
       }
     ],
-    "errorCount": 1,
+    "errorCount": 0,
     "warningCount": 6
   },
   {


### PR DESCRIPTION
## Summary
- let a static negative tabindex override native focusability
- keep invalid and non-negative tabindex values reportable
- add regression coverage for readonly decorative inputs with aria-hidden

## Verification
- RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_patina no_aria_hidden_on_focusable -- --nocapture
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

Fixes #5943

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791608239&installation_model_id=422833&pr_number=5987&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5987&signature=3793e1bc6f71ffb8422b6e96e1d11e779dea2aa0a6cd6562c9efe3d878c8a4a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected accessibility validation for elements with a static negative `tabindex`.
  - Inputs removed from the tab order with `tabindex="-1"` are no longer incorrectly reported when marked `aria-hidden="true"`.
  - Invalid `tabindex` values continue to be treated conservatively as focusable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->