### PR TITLE
fix(patina): report empty explicit lint patterns

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -16,7 +16,7 @@ pub use args::LintArgs;
 
 use crate::profile_support;
 use aggregate::{LintRunAccumulator, should_retain_file_results};
-use collect::{LintIgnoreSet, collect_lint_files, resolve_lint_config_path};
+use collect::{LintIgnoreSet, collect_lint_inputs, resolve_lint_config_path};
 use cross_file::apply_sfc_cross_file_lint;
 use entry_rules::LinterRuleResolver;
 use fix::lint_source_with_optional_fix;
@@ -80,9 +80,8 @@ pub fn run(args: LintArgs) {
         .map(|path| resolve_lint_config_path(config_dir, path));
     let ignore_set = LintIgnoreSet::new(&linter_plan.plan.global_ignores, config_dir);
     let collect_start = Instant::now();
-    let files = collect_lint_files(&args.patterns, ignore_set.as_ref());
+    let (files, input_warnings) = collect_lint_inputs(&args.patterns, ignore_set.as_ref());
     let collect_time = collect_start.elapsed();
-
     if files.is_empty() {
         patterns::write_no_files(format, &args.patterns);
         return;
@@ -209,8 +208,9 @@ pub fn run(args: LintArgs) {
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
 
-    let (lint_error_count, total_warnings) = aggregate::sorted_totals(quiet_totals, &mut results);
+    let (lint_error_count, lint_warnings) = aggregate::sorted_totals(quiet_totals, &mut results);
     let total_errors = lint_error_count + write_failures.load(Ordering::Relaxed);
+    let total_warnings = lint_warnings + input_warnings;
 
     let output_start = Instant::now();
     if render_details {

--- a/crates/vize/src/commands/lint/collect.rs
+++ b/crates/vize/src/commands/lint/collect.rs
@@ -12,6 +12,11 @@ pub(super) struct LintIgnoreSet {
     patterns: Vec<LintInputGlob>,
 }
 
+pub(super) struct LintFileCollection {
+    pub(super) files: Vec<PathBuf>,
+    pub(super) unmatched_patterns: Vec<String>,
+}
+
 impl LintIgnoreSet {
     pub(super) fn new(ignores: &[config::ConfigEntryIgnore], config_dir: &Path) -> Option<Self> {
         let patterns = ignores
@@ -27,39 +32,66 @@ impl LintIgnoreSet {
     }
 }
 
-pub(super) fn collect_lint_files(
+pub(super) fn collect_lint_file_collection(
     patterns: &[String],
     ignore_set: Option<&LintIgnoreSet>,
-) -> Vec<PathBuf> {
+) -> LintFileCollection {
     let mut files = Vec::new();
+    let mut unmatched_patterns = Vec::new();
     let mut seen = FxHashSet::default();
 
     for pattern in patterns {
         let candidate = PathBuf::from(pattern);
         if candidate.exists() {
             if candidate.is_file() {
-                add_lint_file(&candidate, ignore_set, &mut files, &mut seen);
+                if !add_lint_file(&candidate, ignore_set, &mut files, &mut seen) {
+                    unmatched_patterns.push(pattern.clone());
+                }
                 continue;
             }
             if candidate.is_dir() {
-                collect_lint_files_from_dir(&candidate, None, ignore_set, &mut files, &mut seen);
+                if !collect_lint_files_from_dir(&candidate, None, ignore_set, &mut files, &mut seen)
+                {
+                    unmatched_patterns.push(pattern.clone());
+                }
                 continue;
             }
         }
 
         let base_dir = base_dir_from_lint_pattern(pattern);
         let matcher = LintInputGlob::new(pattern);
-        collect_lint_files_from_dir(
+        if !collect_lint_files_from_dir(
             &base_dir,
             matcher.as_ref(),
             ignore_set,
             &mut files,
             &mut seen,
-        );
+        ) {
+            unmatched_patterns.push(pattern.clone());
+        }
     }
 
     files.sort();
-    files
+    LintFileCollection {
+        files,
+        unmatched_patterns,
+    }
+}
+
+pub(super) fn collect_lint_inputs(
+    patterns: &[String],
+    ignore_set: Option<&LintIgnoreSet>,
+) -> (Vec<PathBuf>, usize) {
+    let LintFileCollection {
+        files,
+        unmatched_patterns,
+    } = collect_lint_file_collection(patterns, ignore_set);
+    let warning_count = if files.is_empty() {
+        0
+    } else {
+        super::patterns::write_unmatched_explicit_patterns(patterns, &unmatched_patterns)
+    };
+    (files, warning_count)
 }
 
 fn collect_lint_files_from_dir(
@@ -68,7 +100,8 @@ fn collect_lint_files_from_dir(
     ignore_set: Option<&LintIgnoreSet>,
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
-) {
+) -> bool {
+    let mut matched = false;
     for entry in WalkBuilder::new(dir)
         .standard_filters(true)
         .hidden(matcher.is_none())
@@ -79,9 +112,10 @@ fn collect_lint_files_from_dir(
         };
         let path = entry.path();
         if path.is_file() && matcher.is_none_or(|matcher| matcher.matches(path)) {
-            add_lint_file(path, ignore_set, files, seen);
+            matched |= add_lint_file(path, ignore_set, files, seen);
         }
     }
+    matched
 }
 
 fn add_lint_file(
@@ -89,16 +123,18 @@ fn add_lint_file(
     ignore_set: Option<&LintIgnoreSet>,
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
-) {
+) -> bool {
     if !is_lintable_path(path) {
-        return;
+        return false;
     }
     let normalized = normalize_lint_input_path(path);
-    if !ignore_set.is_some_and(|ignore_set| ignore_set.is_ignored(&normalized))
-        && seen.insert(normalized.clone())
-    {
+    if ignore_set.is_some_and(|ignore_set| ignore_set.is_ignored(&normalized)) {
+        return false;
+    }
+    if seen.insert(normalized.clone()) {
         files.push(normalized);
     }
+    true
 }
 
 fn is_lintable_path(path: &Path) -> bool {
@@ -120,20 +156,28 @@ pub(super) fn is_plain_script_path(path: &Path) -> bool {
 }
 
 fn base_dir_from_lint_pattern(pattern: &str) -> PathBuf {
-    let glob_start = pattern.find(['*', '?', '[', '{']).unwrap_or(pattern.len());
-    let prefix = &pattern[..glob_start];
-    let base = if prefix.is_empty() {
-        "."
-    } else if let Some(index) = prefix.rfind('/') {
-        &prefix[..index]
-    } else {
-        prefix
-    };
-    if base.is_empty() {
-        PathBuf::from(".")
-    } else {
-        PathBuf::from(base)
+    let normalized = normalize_lint_glob_pattern(pattern);
+    let glob_start = normalized
+        .find(['*', '?', '[', '{'])
+        .unwrap_or(normalized.len());
+    let prefix = &normalized[..glob_start];
+    if prefix.is_empty() || (glob_start < normalized.len() && !prefix.contains('/')) {
+        return PathBuf::from(".");
     }
+    if let Some(index) = prefix.rfind('/') {
+        if index == 0 {
+            return PathBuf::from("/");
+        }
+        if is_windows_drive_root(prefix, index) {
+            return PathBuf::from(&prefix[..=index]);
+        }
+        return PathBuf::from(&prefix[..index]);
+    }
+    PathBuf::from(prefix)
+}
+
+fn is_windows_drive_root(prefix: &str, slash_index: usize) -> bool {
+    slash_index == 2 && prefix.as_bytes().get(1) == Some(&b':')
 }
 
 struct LintInputGlob {
@@ -264,83 +308,5 @@ fn lint_glob_match_options() -> MatchOptions {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{LintIgnoreSet, collect_lint_files};
-    use std::fs;
-
-    #[test]
-    fn collection_includes_vue_html_scripts_and_jsx() {
-        let dir = tempfile::tempdir().unwrap();
-        let src = dir.path().join("src");
-        fs::create_dir_all(&src).unwrap();
-        fs::write(src.join("App.vue"), "").unwrap();
-        fs::write(src.join("index.html"), "").unwrap();
-        fs::write(src.join("config.js"), "").unwrap();
-        fs::write(src.join("store.ts"), "").unwrap();
-        fs::write(src.join("Panel.jsx"), "").unwrap();
-        fs::write(src.join("Widget.tsx"), "").unwrap();
-        fs::write(src.join("notes.md"), "").unwrap();
-
-        let files = collect_lint_files(&[src.display().to_string().into()], None);
-
-        assert_eq!(
-            files,
-            vec![
-                src.join("App.vue"),
-                src.join("Panel.jsx"),
-                src.join("Widget.tsx"),
-                src.join("config.js"),
-                src.join("index.html"),
-                src.join("store.ts")
-            ]
-        );
-    }
-
-    #[test]
-    fn collection_applies_config_ignores_and_nested_node_modules() {
-        let dir = tempfile::tempdir().unwrap();
-        let src = dir.path().join("src");
-        let scripts_dep = dir.path().join("scripts/node_modules/chalk/source");
-        fs::create_dir_all(&src).unwrap();
-        fs::create_dir_all(&scripts_dep).unwrap();
-        fs::write(src.join("App.vue"), "").unwrap();
-        fs::write(src.join("Generated.vue"), "").unwrap();
-        fs::write(scripts_dep.join("index.d.ts"), "").unwrap();
-
-        let ignore_set = LintIgnoreSet::new(
-            &[
-                crate::config::ConfigEntryIgnore {
-                    base_path: None,
-                    pattern: "src/Generated.vue".into(),
-                },
-                crate::config::ConfigEntryIgnore {
-                    base_path: None,
-                    pattern: "node_modules/**".into(),
-                },
-            ],
-            dir.path(),
-        );
-        let files = collect_lint_files(
-            &[dir.path().display().to_string().into()],
-            ignore_set.as_ref(),
-        );
-
-        assert_eq!(files, vec![src.join("App.vue")]);
-    }
-
-    #[test]
-    fn recursive_globs_include_dot_directories() {
-        let dir = tempfile::tempdir().unwrap();
-        let docs = dir.path().join("docs/.vitepress/components");
-        fs::create_dir_all(&docs).unwrap();
-        let download_page = docs.join("DownloadPage.vue");
-        fs::write(&download_page, "").unwrap();
-
-        let files = collect_lint_files(
-            &[dir.path().join("**/*.vue").display().to_string().into()],
-            None,
-        );
-
-        assert_eq!(files, vec![download_page]);
-    }
-}
+#[path = "collect_tests.rs"]
+mod tests;

--- a/crates/vize/src/commands/lint/collect_tests.rs
+++ b/crates/vize/src/commands/lint/collect_tests.rs
@@ -1,0 +1,183 @@
+use super::{LintIgnoreSet, base_dir_from_lint_pattern, collect_lint_file_collection};
+use std::fs;
+
+#[test]
+fn root_level_glob_base_dir_is_current_directory() {
+    assert_eq!(
+        base_dir_from_lint_pattern("foo*.vue"),
+        std::path::PathBuf::from(".")
+    );
+    assert_eq!(
+        base_dir_from_lint_pattern("*.vue"),
+        std::path::PathBuf::from(".")
+    );
+    assert_eq!(
+        base_dir_from_lint_pattern("src/foo*.vue"),
+        std::path::PathBuf::from("src")
+    );
+}
+
+#[test]
+fn windows_absolute_glob_base_dir_uses_parent_directory() {
+    assert_eq!(
+        base_dir_from_lint_pattern(r"C:\work\src\foo*.vue"),
+        std::path::PathBuf::from("C:/work/src")
+    );
+    assert_eq!(
+        base_dir_from_lint_pattern(r"C:\*.vue"),
+        std::path::PathBuf::from("C:/")
+    );
+}
+
+#[test]
+fn collection_includes_vue_html_scripts_and_jsx() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("App.vue"), "").unwrap();
+    fs::write(src.join("index.html"), "").unwrap();
+    fs::write(src.join("config.js"), "").unwrap();
+    fs::write(src.join("store.ts"), "").unwrap();
+    fs::write(src.join("Panel.jsx"), "").unwrap();
+    fs::write(src.join("Widget.tsx"), "").unwrap();
+    fs::write(src.join("notes.md"), "").unwrap();
+
+    let files = collect_lint_file_collection(&[src.display().to_string().into()], None).files;
+
+    assert_eq!(
+        files,
+        vec![
+            src.join("App.vue"),
+            src.join("Panel.jsx"),
+            src.join("Widget.tsx"),
+            src.join("config.js"),
+            src.join("index.html"),
+            src.join("store.ts")
+        ]
+    );
+}
+
+#[test]
+fn collection_applies_config_ignores_and_nested_node_modules() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    let scripts_dep = dir.path().join("scripts/node_modules/chalk/source");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&scripts_dep).unwrap();
+    fs::write(src.join("App.vue"), "").unwrap();
+    fs::write(src.join("Generated.vue"), "").unwrap();
+    fs::write(scripts_dep.join("index.d.ts"), "").unwrap();
+
+    let ignore_set = LintIgnoreSet::new(
+        &[
+            crate::config::ConfigEntryIgnore {
+                base_path: None,
+                pattern: "src/Generated.vue".into(),
+            },
+            crate::config::ConfigEntryIgnore {
+                base_path: None,
+                pattern: "node_modules/**".into(),
+            },
+        ],
+        dir.path(),
+    );
+    let files = collect_lint_file_collection(
+        &[dir.path().display().to_string().into()],
+        ignore_set.as_ref(),
+    )
+    .files;
+
+    assert_eq!(files, vec![src.join("App.vue")]);
+}
+
+#[test]
+fn recursive_globs_include_dot_directories() {
+    let dir = tempfile::tempdir().unwrap();
+    let docs = dir.path().join("docs/.vitepress/components");
+    fs::create_dir_all(&docs).unwrap();
+    let download_page = docs.join("DownloadPage.vue");
+    fs::write(&download_page, "").unwrap();
+
+    let files = collect_lint_file_collection(
+        &[dir.path().join("**/*.vue").display().to_string().into()],
+        None,
+    )
+    .files;
+
+    assert_eq!(files, vec![download_page]);
+}
+
+#[test]
+fn collection_reports_each_pattern_with_no_lintable_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    let script = src.join("b.ts");
+    fs::write(&script, "export const x = 1;\n").unwrap();
+
+    let collection = collect_lint_file_collection(
+        &[
+            dir.path().join("src/**/*.ts").display().to_string().into(),
+            dir.path()
+                .join("src/**/*.{vue,ts}")
+                .display()
+                .to_string()
+                .into(),
+            dir.path().join("src/**/*.vue").display().to_string().into(),
+        ],
+        None,
+    );
+
+    assert_eq!(collection.files, vec![script]);
+    assert_eq!(
+        collection.unmatched_patterns,
+        vec![
+            vize_s0::String::from(dir.path().join("src/**/*.{vue,ts}").display().to_string()),
+            vize_s0::String::from(dir.path().join("src/**/*.vue").display().to_string())
+        ]
+    );
+}
+
+#[test]
+fn collection_does_not_report_overlapping_patterns_as_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    let script = src.join("b.ts");
+    fs::write(&script, "export const x = 1;\n").unwrap();
+
+    let collection = collect_lint_file_collection(
+        &[
+            src.display().to_string().into(),
+            dir.path().join("src/**/*.ts").display().to_string().into(),
+        ],
+        None,
+    );
+
+    assert_eq!(collection.files, vec![script]);
+    assert_eq!(collection.unmatched_patterns, Vec::<vize_s0::String>::new());
+}
+
+#[test]
+fn collection_reports_ignored_only_patterns_as_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("Generated.vue"), "").unwrap();
+
+    let ignore_set = LintIgnoreSet::new(
+        &[crate::config::ConfigEntryIgnore {
+            base_path: None,
+            pattern: "src/Generated.vue".into(),
+        }],
+        dir.path(),
+    );
+    let pattern = src.join("Generated.vue").display().to_string();
+    let collection = collect_lint_file_collection(&[pattern.clone().into()], ignore_set.as_ref());
+
+    assert_eq!(collection.files, Vec::<std::path::PathBuf>::new());
+    assert_eq!(
+        collection.unmatched_patterns,
+        vec![vize_s0::String::from(pattern)]
+    );
+}

--- a/crates/vize/src/commands/lint/patterns.rs
+++ b/crates/vize/src/commands/lint/patterns.rs
@@ -23,11 +23,41 @@ pub(super) fn no_lint_files_message(patterns: &[vize_s0::String]) -> vize_s0::St
     vize_s0::cstr!("No {LINT_EXTENSIONS_DISPLAY} files found matching patterns: {patterns:?}")
 }
 
+pub(super) fn unmatched_lint_patterns_message(patterns: &[vize_s0::String]) -> vize_s0::String {
+    vize_s0::cstr!(
+        "Warning: no {LINT_EXTENSIONS_DISPLAY} files found matching patterns: {patterns:?}"
+    )
+}
+
 pub(super) fn write_no_files(format: vize_patina::OutputFormat, patterns: &[vize_s0::String]) {
     eprintln!("{}", no_lint_files_message(patterns));
     if format == vize_patina::OutputFormat::Json {
         super::stdout::write(vize_patina::format_results(&[], &[], format).as_bytes());
     }
+}
+
+pub(super) fn write_unmatched_patterns(patterns: &[vize_s0::String]) {
+    eprintln!("{}", unmatched_lint_patterns_message(patterns));
+}
+
+pub(super) fn write_unmatched_explicit_patterns(
+    input_patterns: &[vize_s0::String],
+    unmatched_patterns: &[vize_s0::String],
+) -> usize {
+    if !has_explicit_patterns(input_patterns) || unmatched_patterns.is_empty() {
+        return 0;
+    }
+    write_unmatched_patterns(unmatched_patterns);
+    unmatched_patterns.len()
+}
+
+#[inline]
+pub(super) fn has_explicit_patterns(patterns: &[vize_s0::String]) -> bool {
+    patterns.len() != LINT_DEFAULT_PATTERNS.len()
+        || patterns
+            .iter()
+            .zip(LINT_DEFAULT_PATTERNS)
+            .any(|(actual, expected)| actual.as_str() != *expected)
 }
 
 #[inline]
@@ -47,7 +77,10 @@ pub(super) fn is_plain_script_extension(extension: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{LINT_DEFAULT_PATTERNS, LINT_EXTENSIONS, LINT_EXTENSIONS_DISPLAY};
+    use super::{
+        LINT_DEFAULT_PATTERNS, LINT_EXTENSIONS, LINT_EXTENSIONS_DISPLAY, has_explicit_patterns,
+        unmatched_lint_patterns_message,
+    };
 
     #[test]
     fn default_patterns_cover_each_lint_extension_once() {
@@ -71,5 +104,31 @@ mod tests {
                 "missing .{extension} from display text"
             );
         }
+    }
+
+    #[test]
+    fn default_lint_patterns_are_not_explicit() {
+        let patterns = LINT_DEFAULT_PATTERNS
+            .iter()
+            .map(|pattern| vize_s0::String::from(*pattern))
+            .collect::<Vec<_>>();
+
+        assert!(!has_explicit_patterns(&patterns));
+        assert!(has_explicit_patterns(&[vize_s0::String::from(
+            "src/**/*.vue"
+        )]));
+    }
+
+    #[test]
+    fn unmatched_pattern_message_lists_every_empty_input() {
+        let output = unmatched_lint_patterns_message(&[
+            vize_s0::String::from("src/**/*.{vue,ts}"),
+            vize_s0::String::from("packages/*/missing.vue"),
+        ]);
+
+        assert_eq!(
+            output,
+            "Warning: no .vue, .html, .htm, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, or .tsx files found matching patterns: [\"src/**/*.{vue,ts}\", \"packages/*/missing.vue\"]"
+        );
     }
 }

--- a/crates/vize/tests/lint_empty_patterns_cli.rs
+++ b/crates/vize/tests/lint_empty_patterns_cli.rs
@@ -1,0 +1,225 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+fn temp_project_dir(test_name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-lint-empty-patterns-{}-{test_name}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn warning_message(patterns: &[&str]) -> String {
+    format!(
+        "Warning: no .vue, .html, .htm, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, or .tsx files found matching patterns: {:?}",
+        patterns
+    )
+}
+
+fn no_files_message(patterns: &[&str]) -> String {
+    format!(
+        "No .vue, .html, .htm, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, or .tsx files found matching patterns: {:?}",
+        patterns
+    )
+}
+
+fn text_summary(stdout: &str) -> (&str, &str) {
+    let lines = stdout.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 3, "{stdout}");
+    assert_eq!(lines[0], "", "{stdout}");
+    let Some(linted_count) = linted_file_count(lines[2]) else {
+        panic!("unexpected linted line: {}", lines[2]);
+    };
+    (lines[1], linted_count)
+}
+
+fn linted_file_count(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("Linted ")?;
+    let (count, _) = rest.split_once(" files in ")?;
+    Some(count)
+}
+
+#[test]
+fn lint_reports_empty_explicit_pattern_when_other_pattern_matches() {
+    let project_root = temp_project_dir("mixed");
+    write_project_file(&project_root, "src/b.ts", "export const x = 1;\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--no-config", "src/**/*.ts", "src/**/*.{vue,ts}"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", output_details(&output));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.as_ref(),
+        format!("{}\n", warning_message(&["src/**/*.{vue,ts}"])),
+        "{}",
+        output_details(&output)
+    );
+    let (summary, linted_count) = text_summary(stdout.as_ref());
+    assert_eq!(
+        summary,
+        "1 warning in 1 file",
+        "{}",
+        output_details(&output)
+    );
+    assert_eq!(linted_count, "1", "{}", output_details(&output));
+
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[test]
+fn lint_counts_empty_explicit_patterns_for_max_warnings() {
+    let project_root = temp_project_dir("max-warnings");
+    write_project_file(&project_root, "src/b.ts", "export const x = 1;\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "lint",
+            "--no-config",
+            "--max-warnings",
+            "0",
+            "src/**/*.ts",
+            "src/**/*.{vue,ts}",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{}", output_details(&output));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.as_ref(),
+        format!(
+            "{}\n\nToo many warnings (1 > max 0)\n",
+            warning_message(&["src/**/*.{vue,ts}"])
+        ),
+        "{}",
+        output_details(&output)
+    );
+    let (summary, linted_count) = text_summary(stdout.as_ref());
+    assert_eq!(
+        summary,
+        "1 warning in 1 file",
+        "{}",
+        output_details(&output)
+    );
+    assert_eq!(linted_count, "1", "{}", output_details(&output));
+
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[test]
+fn lint_collects_root_level_relative_glob_matches() {
+    let project_root = temp_project_dir("root-glob");
+    write_project_file(&project_root, "foo.vue", "<template><div /></template>\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--no-config", "foo*.vue", "missing*.vue"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", output_details(&output));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.as_ref(),
+        format!("{}\n", warning_message(&["missing*.vue"])),
+        "{}",
+        output_details(&output)
+    );
+    let (summary, linted_count) = text_summary(stdout.as_ref());
+    assert_eq!(
+        summary,
+        "1 warning in 1 file",
+        "{}",
+        output_details(&output)
+    );
+    assert_eq!(linted_count, "1", "{}", output_details(&output));
+
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[cfg(windows)]
+#[test]
+fn lint_collects_windows_absolute_glob_from_other_current_dir() {
+    let project_root = temp_project_dir("windows-absolute-glob");
+    let cwd = temp_project_dir("windows-absolute-cwd");
+    fs::create_dir_all(&cwd).unwrap();
+    write_project_file(&project_root, "foo.vue", "<template><div /></template>\n");
+    let pattern = project_root.join("foo*.vue").display().to_string();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&cwd)
+        .args(["lint", "--no-config", pattern.as_str()])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", output_details(&output));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stderr.as_ref(), "", "{}", output_details(&output));
+    let (summary, linted_count) = text_summary(stdout.as_ref());
+    assert_eq!(
+        summary,
+        "No problems found in 1 file(s)",
+        "{}",
+        output_details(&output)
+    );
+    assert_eq!(linted_count, "1", "{}", output_details(&output));
+
+    let _ = fs::remove_dir_all(project_root);
+    let _ = fs::remove_dir_all(cwd);
+}
+
+#[test]
+fn lint_preserves_single_empty_pattern_message() {
+    let project_root = temp_project_dir("single");
+    write_project_file(&project_root, "src/b.ts", "export const x = 1;\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--no-config", "src/**/*.{vue,ts}"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", output_details(&output));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(stdout.as_ref(), "", "{}", output_details(&output));
+    assert_eq!(
+        stderr.as_ref(),
+        format!("{}\n", no_files_message(&["src/**/*.{vue,ts}"])),
+        "{}",
+        output_details(&output)
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |          1135 |                   787 |               348 |             158 |     373 |            1008 |      658 |           560 |           699 |
-| Linter                     |           358 |                   358 |                 0 |             298 |     301 |             719 |      238 |           387 |           567 |
+| Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           568 |
 | Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           500 |           715 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |
@@ -99,20 +99,20 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         358 |             249 |      109 |
+| S0               |         373 |             256 |      117 |
 | old AST/parser   |         256 |             216 |       40 |
 | Croquis analysis |          42 |              37 |        5 |
 | raw OXC          |         301 |             217 |       84 |
 
 #### Top source and manifest files
 
-| file                                                                                | class    | surfaces                                                    | sites |
-| ----------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
-| `crates/vize/src/commands/lint/entry_rules/rule_option_mapping.rs:1`                | source   | S0 14                                                       |    14 |
-| `crates/vize_patina/src/linter/engine.rs:26`                                        | source   | S0 5<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    13 |
-| `crates/vize_patina/Cargo.toml:13`                                                  | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 6 |    10 |
-| `crates/vize_patina/src/rules/script/no_ref_as_operand.rs:29`                       | source   | S0 1<br>raw OXC 9                                           |    10 |
-| `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
+| file                                                                 | class    | surfaces                                                    | sites |
+| -------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
+| `crates/vize/src/commands/lint/entry_rules/rule_option_mapping.rs:1` | source   | S0 14                                                       |    14 |
+| `crates/vize_patina/src/linter/engine.rs:26`                         | source   | S0 5<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    13 |
+| `crates/vize/src/commands/lint/patterns.rs:22`                       | source   | S0 11                                                       |    11 |
+| `crates/vize_patina/Cargo.toml:13`                                   | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 6 |    10 |
+| `crates/vize_patina/src/rules/script/no_ref_as_operand.rs:29`        | source   | S0 1<br>raw OXC 9                                           |    10 |
 
 Additional source/manifest rows are in the TSV: 320 omitted.
 
@@ -126,7 +126,7 @@ Additional source/manifest rows are in the TSV: 320 omitted.
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:35`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1 |     6 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:41`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3 |     6 |
 
-Additional test/dev rows are in the TSV: 70 omitted.
+Additional test/dev rows are in the TSV: 72 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1743,6 +1743,7 @@ linter	Linter	source	crates/vize_patina/src/visitor.rs	7	s0	S0	stage	vize_s0	pre
 linter	Linter	source	crates/vize_patina/src/visitor.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	test/dev	crates/vize/src/commands/lint.rs	34	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize/src/commands/lint/args.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize/src/commands/lint/collect_tests.rs	135	s0	S0	stage	vize_s0	preferred	4
 linter	Linter	source	crates/vize/src/commands/lint/collect.rs	6	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
@@ -1752,7 +1753,8 @@ linter	Linter	test/dev	crates/vize/src/commands/lint/entry_rules_tests.rs	7	s0	S
 linter	Linter	source	crates/vize/src/commands/lint/entry_rules.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize/src/commands/lint/entry_rules/rule_option_mapping.rs	1	s0	S0	stage	vize_s0	preferred	14
 linter	Linter	source	crates/vize/src/commands/lint/fix.rs	8	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize/src/commands/lint/patterns.rs	22	s0	S0	stage	vize_s0	preferred	4
+linter	Linter	source	crates/vize/src/commands/lint/patterns.rs	22	s0	S0	stage	vize_s0	preferred	11
+linter	Linter	test/dev	crates/vize/src/commands/lint/patterns.rs	113	s0	S0	stage	vize_s0	preferred	4
 linter	Linter	source	crates/vize/src/commands/lint/stdout.rs	4	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/benches/package_route.rs	40	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- preserve per-pattern lint collection metadata and report empty explicit patterns when other patterns match
- count empty explicit-pattern reports as lint warnings so --max-warnings 0 can fail CI
- add collector and CLI regression tests, including the single empty-pattern behavior

## Tests
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='"'"'-Cdebuginfo=0'"'"' CARGO_INCREMENTAL=0 cargo test -p vize commands::lint --lib
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='"'"'-Cdebuginfo=0'"'"' CARGO_INCREMENTAL=0 cargo test -p vize --test lint_empty_patterns_cli

Closes #5934

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791608467&installation_model_id=422833&pr_number=5988&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5988&signature=cc3026bbe20547d41ae4643d50c8f5d3b647a6d6da264f90532bfc2f03b4473b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linting now warns when explicitly provided file patterns match no lintable files.
  * Unmatched input patterns are included in warning totals and respected by maximum-warning limits.
  * Linting reports when no files are found without producing misleading output.

* **Tests**
  * Added coverage for unmatched patterns, ignored files, recursive globs, supported file types, and warning-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->