### PR TITLE
fix(patina): keep opinionated rules satisfiable

### DIFF
--- a/crates/vize_patina/src/linter/tests/jsx_no_inline_style.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_inline_style.rs
@@ -53,8 +53,8 @@ fn no_inline_style_fires_on_jsx_and_tsx_markup() {
     let tsx_result = linter.lint_jsx(tsx, "test.tsx", JsxLang::Tsx);
     assert_eq!(
         diagnostic_slices(tsx, &tsx_result),
-        vec![r#"style={{ color: activeColor }}"#],
-        "TSX should use the same authored source range"
+        Vec::<&str>::new(),
+        "TSX dynamic style bindings should stay clean"
     );
 }
 
@@ -85,15 +85,12 @@ fn no_inline_style_reports_multiple_jsx_styles_in_source_order() {
     let source = r#"const A = () => <><div style="color:red" /><span style={{ marginTop }} /></>;"#;
     let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
 
-    assert_eq!(
-        diagnostic_rules(&result),
-        vec!["vue/no-inline-style", "vue/no-inline-style"]
-    );
-    assert_eq!(result.warning_count, 2);
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-inline-style"]);
+    assert_eq!(result.warning_count, 1);
     assert_eq!(result.error_count, 0);
     assert_eq!(
         diagnostic_slices(source, &result),
-        vec![r#"style="color:red""#, r#"style={{ marginTop }}"#]
+        vec![r#"style="color:red""#]
     );
 }
 
@@ -103,13 +100,10 @@ fn no_inline_style_reports_nested_jsx_styles() {
     let source = r#"const A = () => <div>{cond && <span style={dynamicStyles} />}</div>;"#;
     let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
 
-    assert_eq!(diagnostic_rules(&result), vec!["vue/no-inline-style"]);
-    assert_eq!(result.warning_count, 1);
+    assert_eq!(diagnostic_rules(&result), Vec::<&str>::new());
+    assert_eq!(result.warning_count, 0);
     assert_eq!(result.error_count, 0);
-    assert_eq!(
-        diagnostic_slices(source, &result),
-        vec![r#"style={dynamicStyles}"#]
-    );
+    assert_eq!(diagnostic_slices(source, &result), Vec::<&str>::new());
 }
 
 #[test]
@@ -118,13 +112,10 @@ fn no_inline_style_supports_jsx_v_bind_style_spelling() {
     let source = r#"const A = () => <div v-bind:style={styles} />;"#;
     let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
 
-    assert_eq!(diagnostic_rules(&result), vec!["vue/no-inline-style"]);
-    assert_eq!(result.warning_count, 1);
+    assert_eq!(diagnostic_rules(&result), Vec::<&str>::new());
+    assert_eq!(result.warning_count, 0);
     assert_eq!(result.error_count, 0);
-    assert_eq!(
-        diagnostic_slices(source, &result),
-        vec![r#"v-bind:style={styles}"#]
-    );
+    assert_eq!(diagnostic_slices(source, &result), Vec::<&str>::new());
 }
 
 #[test]

--- a/crates/vize_patina/src/markup/tests/no_inline_style_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_inline_style_tests.rs
@@ -93,28 +93,28 @@ fn no_inline_style_template_boundaries() {
         ),
         (
             r#"<div :style="{ color: activeColor }"></div>"#,
-            vec![r#":style="{ color: activeColor }""#],
-            "shorthand dynamic style warns",
+            Vec::<&str>::new(),
+            "shorthand dynamic style stays clean",
         ),
         (
             r#"<div :style.prop="styles"></div>"#,
-            vec![r#":style.prop="styles""#],
-            "modifier dynamic style warns",
+            Vec::<&str>::new(),
+            "modifier dynamic style stays clean",
         ),
         (
             r#"<div v-bind:style="styles"></div>"#,
-            vec![r#"v-bind:style="styles""#],
-            "long-form dynamic style warns",
+            Vec::<&str>::new(),
+            "long-form dynamic style stays clean",
         ),
         (
             r#"<div v-bind:[style]="styles"></div>"#,
-            vec![r#"v-bind:[style]="styles""#],
-            "legacy dynamic style arg warns",
+            Vec::<&str>::new(),
+            "legacy dynamic style arg stays clean",
         ),
         (
             r#"<MyComponent style="color:red" :style="styles" />"#,
-            vec![r#"style="color:red""#, r#":style="styles""#],
-            "component style props keep legacy behavior",
+            vec![r#"style="color:red""#],
+            "component static style props still warn",
         ),
         (
             r#"<div STYLE="color:red"></div>"#,
@@ -182,18 +182,18 @@ fn no_inline_style_jsx_direct_matches_lowered_boundaries() {
         ),
         (
             r#"const A = () => <div style={{ color: activeColor }} />;"#,
-            vec![r#"style={{ color: activeColor }}"#],
-            "expression style warns",
+            Vec::<&str>::new(),
+            "expression style stays clean",
         ),
         (
             r#"const A = () => <div style={dynamicStyles} />;"#,
-            vec![r#"style={dynamicStyles}"#],
-            "identifier expression style warns",
+            Vec::<&str>::new(),
+            "identifier expression style stays clean",
         ),
         (
             r#"const A = () => <div v-bind:style={styles} />;"#,
-            vec![r#"v-bind:style={styles}"#],
-            "JSX directive spelling warns",
+            Vec::<&str>::new(),
+            "JSX directive spelling stays clean",
         ),
         (
             r#"const A = () => <Widget style="color:red" />;"#,
@@ -207,13 +207,13 @@ fn no_inline_style_jsx_direct_matches_lowered_boundaries() {
         ),
         (
             r#"const A = () => <div>{cond && <span style={{ color }} />}</div>;"#,
-            vec![r#"style={{ color }}"#],
-            "nested expression-container JSX style warns",
+            Vec::<&str>::new(),
+            "nested expression-container JSX style stays clean",
         ),
         (
             r#"const A = () => <><div style="color:red" /><span style={{ marginTop }} /></>;"#,
-            vec![r#"style="color:red""#, r#"style={{ marginTop }}"#],
-            "multiple JSX styles report in source order",
+            vec![r#"style="color:red""#],
+            "only static JSX styles report",
         ),
     ] {
         let direct = run_over_jsx_oxc(&rule, source);

--- a/crates/vize_patina/src/rules/css/no_hardcoded_values.rs
+++ b/crates/vize_patina/src/rules/css/no_hardcoded_values.rs
@@ -193,18 +193,18 @@ impl NoHardcodedValues {
         offset: usize,
         result: &mut CssLintResult,
     ) {
-        if let Property::FontSize(size) = property {
-            if Self::is_hardcoded_font_size(size) {
-                result.add_diagnostic(
-                    LintDiagnostic::warn(
-                        META.name,
-                        "Consider using a CSS variable for font-size",
-                        offset as u32,
-                        (offset + 10) as u32,
-                    )
-                    .with_help("Use var(--font-size-name) or relative units (rem, em)"),
-                );
-            }
+        if let Property::FontSize(size) = property
+            && Self::is_hardcoded_font_size(size)
+        {
+            result.add_diagnostic(
+                LintDiagnostic::warn(
+                    META.name,
+                    "Consider using a CSS variable for font-size",
+                    offset as u32,
+                    (offset + 10) as u32,
+                )
+                .with_help("Use var(--font-size-name) or relative units (rem, em)"),
+            );
         }
     }
 

--- a/crates/vize_patina/src/rules/css/no_hardcoded_values.rs
+++ b/crates/vize_patina/src/rules/css/no_hardcoded_values.rs
@@ -16,9 +16,11 @@
 
 use lightningcss::declaration::DeclarationBlock;
 use lightningcss::properties::Property;
+use lightningcss::properties::font::FontSize;
 use lightningcss::rules::CssRule as LCssRule;
 use lightningcss::stylesheet::StyleSheet;
 use lightningcss::values::color::CssColor;
+use lightningcss::values::length::{LengthPercentage, LengthValue};
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 
@@ -192,10 +194,7 @@ impl NoHardcodedValues {
         result: &mut CssLintResult,
     ) {
         if let Property::FontSize(size) = property {
-            // Check if it's a Length type (hardcoded px values)
-            let is_hardcoded = matches!(size, lightningcss::properties::font::FontSize::Length(_));
-
-            if is_hardcoded {
+            if Self::is_hardcoded_font_size(size) {
                 result.add_diagnostic(
                     LintDiagnostic::warn(
                         META.name,
@@ -238,8 +237,28 @@ impl NoHardcodedValues {
 
     #[inline]
     fn is_hardcoded_color(&self, color: &CssColor) -> bool {
-        // Check for non-variable colors (CurrentColor and var() are allowed)
-        !matches!(color, CssColor::CurrentColor)
+        // Check for non-variable colors (CurrentColor, transparent, and var() are allowed).
+        match color {
+            CssColor::CurrentColor => false,
+            CssColor::RGBA(rgba) if rgba.alpha == 0 => false,
+            _ => true,
+        }
+    }
+
+    #[inline]
+    fn is_hardcoded_font_size(size: &FontSize) -> bool {
+        matches!(
+            size,
+            FontSize::Length(LengthPercentage::Dimension(
+                LengthValue::Px(_)
+                    | LengthValue::In(_)
+                    | LengthValue::Cm(_)
+                    | LengthValue::Mm(_)
+                    | LengthValue::Q(_)
+                    | LengthValue::Pt(_)
+                    | LengthValue::Pc(_)
+            ))
+        )
     }
 }
 
@@ -286,6 +305,30 @@ mod tests {
     fn test_valid_current_color() {
         let linter = create_linter();
         let result = linter.lint(".button { color: currentColor; }", 0);
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_transparent_color() {
+        let linter = create_linter();
+        let result = linter.lint(".button { background-color: transparent; }", 0);
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_warns_absolute_font_size() {
+        let linter = create_linter();
+        let result = linter.lint(".button { font-size: 16px; }", 0);
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_relative_font_size() {
+        let linter = create_linter();
+        let result = linter.lint(
+            ".button { font-size: 1.17em; } .title { font-size: 1rem; }",
+            0,
+        );
         assert_eq!(result.warning_count, 0);
     }
 

--- a/crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs
@@ -11,14 +11,13 @@
 //! ### Invalid
 //! ```vue
 //! <div style="color: red">text</div>
-//! <span :style="{ color: 'red' }">text</span>
-//! <p :style="dynamicStyles">text</p>
 //! ```
 //!
 //! ### Valid
 //! ```vue
 //! <div class="text-red">text</div>
 //! <span :class="{ 'text-red': isRed }">text</span>
+//! <div :style="{ width: `${ratio}%` }">text</div>
 //! ```
 //!
 //! ### Exceptions
@@ -45,10 +44,8 @@ pub struct NoInlineStyle;
 
 impl NoInlineStyle {
     fn check_binding(ctx: &mut LintContext<'_>, binding: &MarkupBinding<'_>) {
-        if !matches!(
-            binding.kind(),
-            MarkupBindingKind::Attribute | MarkupBindingKind::Bind
-        ) || !binding.is_unqualified_arg_exact("style")
+        if !matches!(binding.kind(), MarkupBindingKind::Attribute)
+            || !binding.is_unqualified_arg_exact("style")
         {
             return;
         }
@@ -131,10 +128,10 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_dynamic_style() {
+    fn test_valid_dynamic_style() {
         let linter = create_linter();
         let result =
             linter.lint_template(r#"<div :style="{ color: 'red' }">text</div>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_eq!(result.warning_count, 0);
     }
 }

--- a/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
@@ -26,8 +26,8 @@
 //! <!-- Trusted static URLs are safe -->
 //! <a href="/about">About</a>
 //!
-//! <!-- Computed URLs with validation -->
-//! <a :href="sanitizedUrl">Link</a>
+//! <!-- Computed URLs with validation/sanitization -->
+//! <a :href="safeUrl(userProvidedUrl)">Link</a>
 //!
 //! <!-- Using router-link instead of href -->
 //! <router-link :to="{ name: 'profile', params: { id } }">Profile</router-link>
@@ -43,6 +43,10 @@ use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::url::is_unsafe_url;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Expression;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
@@ -115,6 +119,60 @@ fn is_hash_only_href_binding(attr_name: &str, directive: &DirectiveNode) -> bool
     };
 
     is_hash_prefixed_expression(exp.content.trim())
+}
+
+fn is_sanitized_url_binding(directive: &DirectiveNode) -> bool {
+    let Some(ExpressionNode::Simple(exp)) = directive.exp.as_ref() else {
+        return false;
+    };
+
+    expression_is_sanitizer_call(exp.content.trim())
+}
+
+fn expression_is_sanitizer_call(source: &str) -> bool {
+    if !source.contains('(') {
+        return false;
+    }
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    let Ok(parsed) = Parser::new(&allocator, source, source_type).parse_expression() else {
+        return false;
+    };
+    let Some(rest) = source.get(parsed.span().end as usize..) else {
+        return false;
+    };
+    if !rest.trim().is_empty() {
+        return false;
+    }
+
+    let Expression::CallExpression(call) = parsed.get_inner_expression() else {
+        return false;
+    };
+
+    match call.callee.get_inner_expression() {
+        Expression::Identifier(callee) => is_sanitizer_callee_name(callee.name.as_str()),
+        Expression::StaticMemberExpression(member) => {
+            is_sanitizer_callee_name(member.property.name.as_str())
+        }
+        _ => false,
+    }
+}
+
+fn is_sanitizer_callee_name(name: &str) -> bool {
+    matches!(
+        name,
+        "sanitize"
+            | "sanitizeUrl"
+            | "sanitizeURL"
+            | "sanitizedUrl"
+            | "sanitizedURL"
+            | "safe"
+            | "safeUrl"
+            | "safeURL"
+            | "toSafeUrl"
+            | "toSafeURL"
+    )
 }
 
 fn is_hash_prefixed_expression(value: &str) -> bool {
@@ -228,6 +286,10 @@ impl Rule for NoUnsafeUrl {
         }
 
         if is_hash_only_href_binding(attr_name, directive) {
+            return;
+        }
+
+        if is_sanitized_url_binding(directive) {
             return;
         }
 

--- a/crates/vize_patina/src/rules/vue/no_unsafe_url/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url/tests.rs
@@ -94,6 +94,30 @@ fn test_warns_dynamic_href() {
 }
 
 #[test]
+fn test_allows_sanitized_dynamic_href() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<a :href="safe(link)">Link</a>"#, "test.vue");
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_allows_named_url_sanitizer_call() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<a :href="urlSanitizers.safeUrl(userUrl)">Link</a>"#,
+        "test.vue",
+    );
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_warns_unmarked_url_factory_call() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<a :href="getUrl(userUrl)">Link</a>"#, "test.vue");
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
 fn test_allows_dynamic_href_argument() {
     let linter = create_linter();
     let result = linter.lint_template(r#"<a :[href]="userUrl">Link</a>"#, "test.vue");

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |          1133 |                   787 |               346 |             157 |     373 |            1006 |      657 |           557 |           697 |
-| Linter                     |           356 |                   356 |                 0 |             298 |     298 |             714 |      238 |           387 |           567 |
+| Linter                     |           356 |                   356 |                 0 |             298 |     301 |             717 |      238 |           387 |           567 |
 | Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           499 |           713 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |
@@ -102,7 +102,7 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 | S0               |         356 |             247 |      109 |
 | old AST/parser   |         256 |             216 |       40 |
 | Croquis analysis |          42 |              37 |        5 |
-| raw OXC          |         298 |             214 |       84 |
+| raw OXC          |         301 |             217 |       84 |
 
 #### Top source and manifest files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1310,7 +1310,7 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_array_index
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	32	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -1653,6 +1653,9 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/no_textarea_mustache.rs	24
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsafe_url.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsafe_url.rs	46	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsafe_url.rs	46	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsafe_url.rs	46	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsandboxed_iframe.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	41	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	2


### PR DESCRIPTION
## Summary
- allow explicit sanitizer call expressions for `vue/no-unsafe-url` while keeping bare dynamic URLs reported
- report `vue/no-inline-style` only for static style attributes so runtime geometry bindings stay usable
- allow documented relative font-size units and transparent colors in `css/no-hardcoded-values`

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize_patina no_inline_style -- --nocapture`
- `cargo test -p vize_patina no_hardcoded_values -- --nocapture`
- `cargo test -p vize_patina no_unsafe_url -- --nocapture`
- `cargo test -p vize_patina --lib`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350`
- `git diff --check`

Fixes #5940

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791608884&installation_model_id=422833&pr_number=5989&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5989&signature=cc9e9a5bc7b4760bdb21ef708203d2f9ba547eef897e5ac28cfef9c5cf265840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->