### PR TITLE
test(patina): cover string-only class arrays

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs
@@ -219,6 +219,36 @@ defineProps<{ device: string; isVertical: boolean }>();
     }
 
     #[test]
+    fn allows_static_string_and_string_ternaries() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r##"<script setup lang="ts">
+interface Props {
+  cols?: number | string;
+  alignSelf?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  cols: undefined,
+  alignSelf: undefined,
+});
+</script>
+
+<template>
+  <div
+    :class="[
+      'zz-col',
+      props.cols ? `zz-col-${props.cols}` : '',
+      props.alignSelf ? `zz-col-align-self-${props.alignSelf}` : ''
+    ]"
+  />
+</template>"##,
+            "App.vue",
+        );
+        assert_eq!(result.warning_count, 0, "got: {:?}", result.diagnostics);
+    }
+
+    #[test]
     fn ignores_braces_inside_string_literals() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div :class="['{', { a: b }]" />"#, "App.vue");


### PR DESCRIPTION
Closes #5947.

## Summary
- add the exact :class regression with a static class plus string-returning ternaries
- keep the parser-backed rule contract pinned at zero warnings when no object literals exist

## Verification
- cargo fmt --all --check
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo test -p vize_patina no_multiple_objects_in_class -- --nocapture
- node --test tests/tooling/davinci-matrices.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791610014&installation_model_id=422833&pr_number=5990&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5990&signature=4cefa4e6913e6e83a99feda462792eb00cce12b05667874870bae0e2161de0b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->