### PR TITLE
test(patina): cover id before key attribute order

### DIFF
--- a/crates/vize_patina/src/rules/vue/attribute_order.rs
+++ b/crates/vize_patina/src/rules/vue/attribute_order.rs
@@ -169,6 +169,22 @@ mod tests {
     }
 
     #[test]
+    fn global_id_precedes_unique_key_and_ref() {
+        let linter = create_linter();
+        let valid = linter.lint_template(
+            r#"<div v-for="item in items" :id="item.k" :key="item.k" ref="el" class="x" />"#,
+            "test.vue",
+        );
+        assert_eq!(valid.warning_count, 0, "got: {:?}", valid.diagnostics);
+
+        let invalid = linter.lint_template(
+            r#"<div v-for="item in items" :key="item.k" :id="item.k" class="x" />"#,
+            "test.vue",
+        );
+        assert_eq!(invalid.warning_count, 1, "got: {:?}", invalid.diagnostics);
+    }
+
+    #[test]
     fn directives_participate_in_ordering() {
         let linter = create_linter();
         let result =


### PR DESCRIPTION
Closes #5948.

## Summary
- add the issue repro showing Vue style guide order accepts global id before unique key/ref
- assert the opposite key-before-id order still reports

## Verification
- cargo fmt --all --check
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 cargo test -p vize_patina attribute_order -- --nocapture
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target RUSTFLAGS='-Cdebuginfo=0' CARGO_INCREMENTAL=0 rust-script tools/commands/davinci/consumer-migration-surfaces.rs --write
- node --test tests/tooling/davinci-matrices.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791610259&installation_model_id=422833&pr_number=5992&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5992&signature=173469772a4580ea367997d6789694d910a2cd976432111690458f9e73afaf35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->