### PR TITLE
fix(patina): ignore plain module option-shaped objects

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -164,6 +164,7 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
     .then(|| template_ast::parse_for_script_rules(linter, descriptor, &template_allocator))
     .flatten();
     let sfc_context = SfcScriptContext {
+        is_sfc: true,
         template_source: descriptor
             .template
             .as_ref()
@@ -172,8 +173,7 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
         template_offset: template_ast.as_ref().map(|ast| ast.offset),
         // Both blocks are linted separately below, so a whole-file conclusion
         // is only available to a rule when there is a single block to draw it
-        // from. Computed from the descriptor rather than from the filtered
-        // `script` / `script_setup` bindings: a block skipped by the prefilter
+        // from. Computed from the descriptor rather than filtered bindings: a skipped block
         // still contributes declarations a rule would need to see.
         sole_script_block: descriptor.script.is_some() != descriptor.script_setup.is_some(),
     };

--- a/crates/vize_patina/src/linter/tests/script.rs
+++ b/crates/vize_patina/src/linter/tests/script.rs
@@ -41,3 +41,51 @@ const instance = getCurrentInstance();
             .any(|diagnostic| diagnostic.rule_name == "script/no-get-current-instance")
     );
 }
+
+#[test]
+fn lint_script_allows_generated_default_exported_data_objects() {
+    let source = r#"
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+export default {
+  breakpoint: {
+    m: {
+      key: '{breakpoint.m}',
+      value: 960,
+      type: 'dimension'
+    }
+  }
+}
+"#;
+    let result = Linter::with_preset(LintPreset::Opinionated).lint_script(source, "tokens.js");
+
+    assert_eq!(result.error_count, 0, "{:?}", result.diagnostics);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "script/no-options-api")
+    );
+}
+
+#[test]
+fn lint_script_allows_plain_config_object_with_option_like_keys() {
+    let source = r#"
+const config = {
+  ssg: { siteName: "docs" },
+  data: { items: [] }
+};
+
+export default config;
+"#;
+    let result = Linter::with_preset(LintPreset::Opinionated).lint_script(source, "site.config.ts");
+
+    assert_eq!(result.error_count, 0, "{:?}", result.diagnostics);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "script/no-options-api")
+    );
+}

--- a/crates/vize_patina/src/rules/script/no_options_api.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api.rs
@@ -30,7 +30,7 @@
 //! watch(count, (val) => console.log(val))
 //! ```
 
-use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::{
     Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
@@ -59,15 +59,25 @@ impl ScriptRule for NoOptionsApi {
         true
     }
 
-    #[inline]
     fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        self.check_program_with_sfc(program, source, offset, SfcScriptContext::default(), result);
+    }
+
+    fn check_program_with_sfc<'a>(
         &self,
         program: &'a Program<'a>,
         _source: &str,
         offset: usize,
+        sfc: SfcScriptContext<'_>,
         result: &mut ScriptLintResult,
     ) {
-        let Some(component_options) = find_component_options(program) else {
+        let Some(component_options) = find_component_options(program, sfc.is_sfc) else {
             return;
         };
 
@@ -124,16 +134,15 @@ struct OptionLabel {
     end: u32,
 }
 
-fn find_component_options<'a>(program: &'a Program<'a>) -> Option<ComponentOptionsMatch> {
+fn find_component_options<'a>(
+    program: &'a Program<'a>,
+    allow_sfc_default_export: bool,
+) -> Option<ComponentOptionsMatch> {
     let mut bindings = FxHashMap::default();
     let mut petite_vue = PetiteVueBindings::default();
-    let mut imports_vue_runtime = false;
 
     for statement in program.body.iter() {
         collect_petite_vue_imports(statement, &mut petite_vue);
-        if imports_vue_runtime_module(statement) {
-            imports_vue_runtime = true;
-        }
     }
 
     for statement in program.body.iter() {
@@ -164,7 +173,7 @@ fn find_component_options<'a>(program: &'a Program<'a>) -> Option<ComponentOptio
             &export.declaration,
             &bindings,
             &petite_vue,
-            imports_vue_runtime,
+            allow_sfc_default_export,
         ) else {
             continue;
         };
@@ -187,7 +196,7 @@ fn extract_component_options_from_export<'a>(
     declaration: &'a ExportDefaultDeclarationKind<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
     petite_vue: &PetiteVueBindings<'a>,
-    imports_vue_runtime: bool,
+    allow_sfc_default_export: bool,
 ) -> Option<ComponentOptionsRef<'a>> {
     let options = match declaration {
         ExportDefaultDeclarationKind::ObjectExpression(object) => Some(ComponentOptionsRef {
@@ -219,8 +228,7 @@ fn extract_component_options_from_export<'a>(
         _ => None,
     }?;
 
-    if options.explicit_component || imports_vue_runtime || has_component_option_key(options.object)
-    {
+    if options.explicit_component || allow_sfc_default_export {
         Some(options)
     } else {
         None
@@ -414,16 +422,6 @@ fn extract_component_options_from_argument<'a>(
     }
 }
 
-fn imports_vue_runtime_module(statement: &Statement<'_>) -> bool {
-    let Statement::ImportDeclaration(import) = statement else {
-        return false;
-    };
-    matches!(
-        import.source.value.as_str(),
-        "vue" | "@vue/runtime-core" | "@vue/runtime-dom"
-    )
-}
-
 fn collect_petite_vue_imports<'a>(
     statement: &'a Statement<'a>,
     petite_vue: &mut PetiteVueBindings<'a>,
@@ -558,6 +556,7 @@ fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
     }
 }
 
+#[cfg(test)]
 fn has_component_option_key(object: &ObjectExpression<'_>) -> bool {
     object.properties.iter().any(|property| {
         let ObjectPropertyKind::ObjectProperty(property) = property else {
@@ -570,6 +569,7 @@ fn has_component_option_key(object: &ObjectExpression<'_>) -> bool {
     })
 }
 
+#[cfg(test)]
 fn is_component_option_name(name: &str) -> bool {
     matches!(
         name,

--- a/crates/vize_patina/src/rules/script/no_options_api/tests.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    NoOptionsApi, ScriptLintResult, ScriptRule, has_component_option_key,
-    imports_vue_runtime_module, is_component_option_name,
+    NoOptionsApi, ScriptLintResult, ScriptRule, SfcScriptContext, has_component_option_key,
+    is_component_option_name,
 };
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
@@ -10,6 +10,32 @@ fn parse_program<'a>(allocator: &'a Allocator, source: &'a str) -> oxc_ast::ast:
     Parser::new(allocator, source, SourceType::ts())
         .parse()
         .program
+}
+
+fn lint_script(source: &str) -> ScriptLintResult {
+    let rule = NoOptionsApi;
+    let mut result = ScriptLintResult::default();
+    rule.check(source, 0, &mut result);
+    result
+}
+
+fn lint_sfc_script(source: &str) -> ScriptLintResult {
+    let allocator = Allocator::default();
+    let program = parse_program(&allocator, source);
+    let rule = NoOptionsApi;
+    let mut result = ScriptLintResult::default();
+    rule.check_program_with_sfc(
+        &program,
+        source,
+        0,
+        SfcScriptContext {
+            is_sfc: true,
+            sole_script_block: true,
+            ..Default::default()
+        },
+        &mut result,
+    );
+    result
 }
 
 #[test]
@@ -23,26 +49,13 @@ fn test_component_option_names_cover_vue_options() {
 }
 
 #[test]
-fn test_vue_runtime_import_detection() {
-    let allocator = Allocator::default();
-    let program = parse_program(&allocator, "import { h } from 'vue'\n");
-    assert!(program.body.iter().any(imports_vue_runtime_module));
-
-    let allocator = Allocator::default();
-    let program = parse_program(&allocator, "import { createApp } from 'petite-vue'\n");
-    assert!(!program.body.iter().any(imports_vue_runtime_module));
-}
-
-#[test]
 fn test_valid_composition_api() {
     let source = r#"
 import { ref, computed } from 'vue'
 const count = ref(0)
 const doubled = computed(() => count.value * 2)
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0);
 }
 
@@ -58,9 +71,7 @@ export default {
   }
 }
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0, "got: {:?}", result.diagnostics);
 }
 
@@ -74,14 +85,12 @@ export default {
   }
 }
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0, "got: {:?}", result.diagnostics);
 }
 
 #[test]
-fn test_default_export_with_vue_import_is_component_options() {
+fn test_plain_default_export_with_vue_import_is_not_options_api() {
     let source = r#"
 import { h } from 'vue'
 
@@ -89,11 +98,8 @@ export default {
   customOption: true
 }
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
-    assert_eq!(result.error_count, 1);
-    assert_eq!(result.diagnostics[0].rule_name, "script/no-options-api");
+    let result = lint_script(source);
+    assert_eq!(result.error_count, 0, "got: {:?}", result.diagnostics);
 }
 
 #[test]
@@ -105,9 +111,7 @@ export default {
   }
 }
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_sfc_script(source);
     assert_eq!(result.error_count, 1);
     insta::assert_debug_snapshot!(result.diagnostics);
 }
@@ -140,9 +144,10 @@ export default {
         .expect("default object export");
     assert!(has_component_option_key(export));
 
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
+    assert_eq!(result.error_count, 0, "got: {:?}", result.diagnostics);
+
+    let result = lint_sfc_script(source);
     assert_eq!(result.error_count, 1);
     assert_eq!(result.diagnostics[0].rule_name, "script/no-options-api");
 }
@@ -158,9 +163,7 @@ export default defineComponent({
   }
 })
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 1);
     insta::assert_debug_snapshot!(result.diagnostics);
 }
@@ -176,9 +179,7 @@ const component = {
 
 export default component
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_sfc_script(source);
     assert_eq!(result.error_count, 1);
     insta::assert_debug_snapshot!(result.diagnostics);
 }
@@ -191,9 +192,7 @@ export default {
   inheritAttrs: false
 }
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_sfc_script(source);
     assert_eq!(result.error_count, 1);
     insta::assert_debug_snapshot!(result.diagnostics);
 }
@@ -207,9 +206,7 @@ Vue.createApp({
   }
 }).mount("#app")
 "##;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 1);
     insta::assert_debug_snapshot!(result.diagnostics);
 }
@@ -226,9 +223,7 @@ const options = {
 
 createApp(options).mount("#app")
 "##;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 1);
     insta::assert_debug_snapshot!(result.diagnostics);
 }
@@ -243,9 +238,7 @@ PetiteVue.createApp({
   }
 }).mount()
 "##;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0);
 }
 
@@ -261,9 +254,7 @@ createApp({
   }
 }).mount()
 "##;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0);
 }
 
@@ -279,9 +270,7 @@ createPetiteApp({
   }
 }).mount()
 "##;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0);
 }
 
@@ -297,9 +286,7 @@ createApp({
   }
 }).mount()
 "##;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0);
 }
 
@@ -315,9 +302,7 @@ Vue.createApp({
   }
 }).mount()
 "##;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0);
 }
 
@@ -326,8 +311,6 @@ fn test_no_export_default_skip() {
     let source = r#"
 const computed = { foo: 'bar' }
 "#;
-    let rule = NoOptionsApi;
-    let mut result = ScriptLintResult::default();
-    rule.check(source, 0, &mut result);
+    let result = lint_script(source);
     assert_eq!(result.error_count, 0);
 }

--- a/crates/vize_patina/src/rules/script/sfc_context.rs
+++ b/crates/vize_patina/src/rules/script/sfc_context.rs
@@ -46,6 +46,14 @@ use vize_relief::RootNode;
 /// an SFC. See the module documentation for how the three channels differ.
 #[derive(Clone, Copy, Default)]
 pub struct SfcScriptContext<'a> {
+    /// Whether the current script block came from a parsed SFC descriptor.
+    ///
+    /// Standalone JavaScript/TypeScript files and inline HTML scripts use the
+    /// default value (`false`). Rules that need SFC-only conclusions should
+    /// check this rather than inferring from offsets or template presence: an
+    /// SFC may omit `<template>`, and an inline HTML script has a non-zero
+    /// source offset.
+    pub is_sfc: bool,
     /// Raw `<template>` block content, when the SFC declares a template.
     pub template_source: Option<&'a str>,
     /// Parsed `<template>` AST, when the SFC declares a template, some enabled


### PR DESCRIPTION
## Summary
- carry SFC context into script rules so `script/no-options-api` can distinguish SFC `<script>` from standalone `.js`/`.ts` modules
- keep standalone default-exported data/config objects lint-clean unless they are passed to component APIs
- preserve Options API diagnostics for SFC default exports and explicit `defineComponent()` / `createApp()` options

Fixes #5939.
Fixes #5944.

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize_patina no_options_api -- --nocapture`
- `cargo test -p vize_patina linter::tests::script -- --nocapture`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791612514&installation_model_id=422833&pr_number=6003&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6003&signature=e652e9b82b328883c052dd0324fd04ffd94f3d264b1d4f7572d9f502d4b6713e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script linting to distinguish Vue single-file components from standalone JavaScript or TypeScript files.
  * Prevented false positives for plain configuration objects and generated default exports in standalone scripts.
  * Continued identifying unsupported Options API usage in Vue single-file components.

* **Tests**
  * Added coverage for generated data objects, option-like configuration keys, and differing standalone-script versus SFC behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->