### PR TITLE
fix(canon): preserve template ts suppression comments

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_ref_slot_vnode_handlers.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_ref_slot_vnode_handlers.rs
@@ -188,6 +188,45 @@ function acceptElement(element: Element) {
 }
 
 #[test]
+fn template_expressions_preserve_authored_ts_suppression_comments() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "template-expression-ts-suppression-comments",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const items: { id: number }[] = [{ id: 1 }]
+</script>
+
+<template>
+  <div>
+    {{
+      // @ts-ignore
+      items[0].missingProperty
+    }}
+    {{
+      // @ts-expect-error
+      items[0].alsoMissing
+    }}
+  </div>
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    assert_eq!(
+        snapshot,
+        Some(Vec::new()),
+        "template expression generation should preserve authored TypeScript suppression comments"
+    );
+}
+
+#[test]
 fn unresolved_global_component_ref_callbacks_do_not_emit_standalone_any() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -28,6 +28,7 @@ mod reserved_props;
 mod sequence_prop_tests;
 mod spread_reserved_props;
 mod statements;
+mod ts_suppression_comments;
 mod value_checks;
 mod vif_chain;
 

--- a/crates/vize_canon/src/virtual_ts/expressions/statements.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/statements.rs
@@ -10,6 +10,7 @@ use super::component_ref_callbacks::generate_component_ref_callback_statement;
 use super::directive_values::generate_directive_value_statement;
 use super::native_props::generate_native_prop_statement;
 use super::reserved_props::rewrite_reserved_template_prop;
+use super::ts_suppression_comments::expression_source_for_typecheck;
 use super::value_checks::TemplateValueChecks;
 use super::vif_chain::{VifControlFlowChain, emit_vif_control_flow_chain};
 use crate::virtual_ts::scope::{append_ignored_vif_guard_open, remove_enclosing_vif_guard_prefix};
@@ -21,7 +22,6 @@ use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
 use vize_croquis::croquis::{TemplateExpression, TemplateExpressionKind};
-use vize_croquis::drawer::strip_js_comments;
 
 /// Generate template expressions, compacting recognized v-if chains into
 /// TypeScript control-flow blocks.
@@ -202,7 +202,7 @@ fn generate_vif_guard_expression(
     let src_end = (template_offset + expr.end) as usize;
     let expression = profile!(
         "canon.virtual_ts.expression.strip_comments",
-        strip_js_comments(expr.content.as_str())
+        expression_source_for_typecheck(expr.content.as_str())
     );
     let trimmed_expression = expression.as_ref().trim();
     let rewritten_expression =
@@ -259,7 +259,7 @@ pub(super) fn generate_expression_statement(
     } else {
         profile!(
             "canon.virtual_ts.expression.strip_comments",
-            strip_js_comments(expr.content.as_str())
+            expression_source_for_typecheck(expr.content.as_str())
         )
     };
     let trimmed_expression = expression.as_ref().trim();

--- a/crates/vize_canon/src/virtual_ts/expressions/ts_suppression_comments.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/ts_suppression_comments.rs
@@ -99,10 +99,9 @@ mod tests {
     fn strips_non_leading_suppression_comments() {
         let object_literal = "{ name: 'route',\n// @ts-expect-error upstream note\nparams }";
         assert!(!contains_typescript_suppression_comment(object_literal));
-        assert!(
-            !expression_source_for_typecheck(object_literal)
-                .as_ref()
-                .contains("@ts-expect-error")
+        assert_eq!(
+            expression_source_for_typecheck(object_literal).as_ref(),
+            "{ name: 'route',\n\nparams }"
         );
     }
 }

--- a/crates/vize_canon/src/virtual_ts/expressions/ts_suppression_comments.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/ts_suppression_comments.rs
@@ -1,0 +1,125 @@
+use std::borrow::Cow;
+use vize_croquis::drawer::strip_js_comments;
+
+pub(super) fn expression_source_for_typecheck(expr: &str) -> Cow<'_, str> {
+    if contains_typescript_suppression_comment(expr) {
+        Cow::Borrowed(expr)
+    } else {
+        strip_js_comments(expr)
+    }
+}
+
+fn contains_typescript_suppression_comment(expr: &str) -> bool {
+    let bytes = expr.as_bytes();
+    let len = bytes.len();
+    let mut index = 0;
+
+    while index < len {
+        let current = bytes[index];
+
+        if current == b'\'' || current == b'"' || current == b'`' {
+            index = skip_quoted_literal(bytes, index);
+            continue;
+        }
+
+        if current == b'/' && index + 1 < len && !is_escaped(bytes, index) {
+            let next = bytes[index + 1];
+            if next == b'/' {
+                let start = index + 2;
+                let mut end = start;
+                while end < len && bytes[end] != b'\n' {
+                    end += 1;
+                }
+                if is_typescript_suppression_directive(&expr[start..end]) {
+                    return true;
+                }
+                index = end;
+                if index < len {
+                    index += 1;
+                }
+                continue;
+            }
+
+            if next == b'*' {
+                let start = index + 2;
+                index += 2;
+                while index + 1 < len && !(bytes[index] == b'*' && bytes[index + 1] == b'/') {
+                    index += 1;
+                }
+                let end = index.min(len);
+                if is_typescript_suppression_directive(&expr[start..end]) {
+                    return true;
+                }
+                index = (index + 2).min(len);
+                continue;
+            }
+        }
+
+        index += 1;
+    }
+
+    false
+}
+
+fn skip_quoted_literal(bytes: &[u8], start: usize) -> usize {
+    let quote = bytes[start];
+    let mut index = start + 1;
+    while index < bytes.len() {
+        let current = bytes[index];
+        index += 1;
+
+        if current == b'\\' {
+            index = (index + 1).min(bytes.len());
+            continue;
+        }
+
+        if current == quote {
+            break;
+        }
+    }
+    index
+}
+
+fn is_typescript_suppression_directive(comment: &str) -> bool {
+    let trimmed = comment.trim_start();
+    trimmed.starts_with("@ts-ignore") || trimmed.starts_with("@ts-expect-error")
+}
+
+fn is_escaped(bytes: &[u8], index: usize) -> bool {
+    let mut cursor = index;
+    while cursor > 0 && bytes[cursor - 1] == b'\\' {
+        cursor -= 1;
+    }
+    (index - cursor) % 2 == 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_typescript_suppression_comment, expression_source_for_typecheck};
+
+    #[test]
+    fn preserves_only_typescript_suppression_comments() {
+        assert_eq!(
+            expression_source_for_typecheck("// note\nvalue").as_ref(),
+            "\nvalue"
+        );
+        assert_eq!(
+            expression_source_for_typecheck("// @ts-ignore\nvalue").as_ref(),
+            "// @ts-ignore\nvalue"
+        );
+        assert_eq!(
+            expression_source_for_typecheck("/* @ts-expect-error */\nvalue").as_ref(),
+            "/* @ts-expect-error */\nvalue"
+        );
+    }
+
+    #[test]
+    fn ignores_suppression_text_inside_literals() {
+        assert!(!contains_typescript_suppression_comment(
+            r#""// @ts-ignore" + value"#
+        ));
+        assert!(!contains_typescript_suppression_comment(
+            r#"`/* @ts-expect-error */` + value"#
+        ));
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/expressions/ts_suppression_comments.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/ts_suppression_comments.rs
@@ -15,14 +15,13 @@ fn contains_typescript_suppression_comment(expr: &str) -> bool {
     let mut index = 0;
 
     while index < len {
-        let current = bytes[index];
-
-        if current == b'\'' || current == b'"' || current == b'`' {
-            index = skip_quoted_literal(bytes, index);
-            continue;
+        while index < len && bytes[index].is_ascii_whitespace() {
+            index += 1;
         }
-
-        if current == b'/' && index + 1 < len && !is_escaped(bytes, index) {
+        if index + 1 >= len || bytes[index] != b'/' {
+            return false;
+        }
+        {
             let next = bytes[index + 1];
             if next == b'/' {
                 let start = index + 2;
@@ -55,42 +54,15 @@ fn contains_typescript_suppression_comment(expr: &str) -> bool {
             }
         }
 
-        index += 1;
+        return false;
     }
 
     false
 }
 
-fn skip_quoted_literal(bytes: &[u8], start: usize) -> usize {
-    let quote = bytes[start];
-    let mut index = start + 1;
-    while index < bytes.len() {
-        let current = bytes[index];
-        index += 1;
-
-        if current == b'\\' {
-            index = (index + 1).min(bytes.len());
-            continue;
-        }
-
-        if current == quote {
-            break;
-        }
-    }
-    index
-}
-
 fn is_typescript_suppression_directive(comment: &str) -> bool {
     let trimmed = comment.trim_start();
     trimmed.starts_with("@ts-ignore") || trimmed.starts_with("@ts-expect-error")
-}
-
-fn is_escaped(bytes: &[u8], index: usize) -> bool {
-    let mut cursor = index;
-    while cursor > 0 && bytes[cursor - 1] == b'\\' {
-        cursor -= 1;
-    }
-    (index - cursor) % 2 == 1
 }
 
 #[cfg(test)]
@@ -121,5 +93,16 @@ mod tests {
         assert!(!contains_typescript_suppression_comment(
             r#"`/* @ts-expect-error */` + value"#
         ));
+    }
+
+    #[test]
+    fn strips_non_leading_suppression_comments() {
+        let object_literal = "{ name: 'route',\n// @ts-expect-error upstream note\nparams }";
+        assert!(!contains_typescript_suppression_comment(object_literal));
+        assert!(
+            !expression_source_for_typecheck(object_literal)
+                .as_ref()
+                .contains("@ts-expect-error")
+        );
     }
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |          1135 |                   787 |               348 |             158 |     373 |            1008 |      658 |           560 |           699 |
 | Linter                     |           358 |                   358 |                 0 |             298 |     301 |             719 |      238 |           387 |           567 |
-| Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           499 |           713 |
+| Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           500 |           714 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |
 | LSP                        |           301 |                   301 |                 0 |             115 |      47 |             349 |      114 |           174 |           410 |
@@ -147,9 +147,9 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 | `crates/vize/src/commands/check/nuxt/parsing.rs:5`                             | source   | S0 1<br>raw OXC 11                                          |    12 |
 | `crates/vize_canon/Cargo.toml:16`                                              | manifest | S0 1<br>old AST/parser 3<br>Croquis analysis 1<br>raw OXC 6 |    11 |
 | `crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs:7` | source   | S0 10                                                       |    10 |
-| `crates/vize_canon/src/virtual_ts/expressions/statements.rs:17`                | source   | S0 6<br>Croquis analysis 3                                  |     9 |
+| `crates/vize_canon/src/virtual_ts/scope/context.rs:3`                          | source   | S0 4<br>old AST/parser 2<br>Croquis analysis 3              |     9 |
 
-Additional source/manifest rows are in the TSV: 331 omitted.
+Additional source/manifest rows are in the TSV: 332 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2185,9 +2185,10 @@ typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spre
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/statements.rs	17	s0	S0	stage	vize_carton	compat	6
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/statements.rs	17	croquis	Croquis analysis	old	vize_croquis	legacy	3
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/statements.rs	18	s0	S0	stage	vize_carton	compat	6
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/statements.rs	18	croquis	Croquis analysis	old	vize_croquis	legacy	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/tests.rs	2	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/ts_suppression_comments.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/value_checks.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs	5	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	2

--- a/davinci-road/plan/croquis-consumption.md
+++ b/davinci-road/plan/croquis-consumption.md
@@ -347,7 +347,7 @@ Items consumers import from `vize_croquis` that are outside the product set abov
 | `prod_scoped_v_bind_name`                    | `vize_atelier_sfc`   |     1 |     1 |
 | `runtime_erased_macro_names`                 | `vize_atelier_sfc`   |     3 |     5 |
 | `scoped_v_bind_name`                         | `vize_atelier_sfc`   |     1 |     1 |
-| `strip_js_comments`                          | `vize_canon`         |     3 |     4 |
+| `strip_js_comments`                          | `vize_canon`         |     3 |     3 |
 | `to_pascal_case`                             | `vize`               |     1 |     1 |
 | `to_pascal_case`                             | `vize_canon`         |     2 |     2 |
 | `to_pascal_case`                             | `vize_patina`        |     2 |     3 |


### PR DESCRIPTION
## Summary
- keep authored @ts-ignore and @ts-expect-error comments in generated template expression TypeScript
- continue stripping ordinary template expression comments on the common path
- add regression coverage for template interpolation suppression comments

Fixes #5998

## Verification
- cargo fmt --all --check
- cargo test -p vize_canon suppression -- --nocapture
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791614637&installation_model_id=422833&pr_number=6009&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6009&signature=9dc8500101310a95ab4184ea2600bda45e648149a368a730dd091c47f6931bd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved authored `@ts-ignore` and `@ts-expect-error` comments in Vue template expressions during TypeScript checking.
  * Continued removing ordinary JavaScript comments while retaining leading TypeScript suppression directives.
* **Tests**
  * Added coverage for suppression comments in template expressions, including comments inside literals and non-leading comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->