### PR TITLE
fix(sfc): preserve slotted nesting scope

### DIFF
--- a/crates/vize_atelier_sfc/src/css/scoped.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped.rs
@@ -3,7 +3,11 @@
 //! Applies Vue-style scoped CSS by adding attribute selectors (e.g., `[data-v-xxx]`)
 //! to CSS selectors. Handles special pseudo-selectors: `:deep()`, `:slotted()`, `:global()`.
 
+mod slotted;
+
 use vize_carton::{Allocator, Vec as ArenaVec};
+
+pub(super) use slotted::transform_slotted;
 
 use super::scoped_selector::{
     find_top_level_pseudo, leading_universal_selector_end,
@@ -448,34 +452,6 @@ fn trailing_combinator_start(value: &str) -> Option<usize> {
         b'>' | b'+' | b'~' => Some(bytes.len() - 1),
         b'|' if bytes.len() >= 2 && bytes[bytes.len() - 2] == b'|' => Some(bytes.len() - 2),
         _ => None,
-    }
-}
-
-/// Transform :slotted() for slot content
-pub(super) fn transform_slotted(
-    out: &mut ArenaVec<u8>,
-    selector: &str,
-    start: usize,
-    attr_selector: &[u8],
-) {
-    let after = &selector[start + 9..];
-
-    if let Some(end) = find_matching_paren(after) {
-        let inner = &after.as_bytes()[..end];
-        let rest = &after.as_bytes()[end + 1..];
-
-        out.extend_from_slice(inner);
-        // Convert [data-v-xxx] to [data-v-xxx-s] for slotted styles
-        if attr_selector.last() == Some(&b']') {
-            out.extend_from_slice(&attr_selector[..attr_selector.len() - 1]);
-            out.extend_from_slice(b"-s]");
-        } else {
-            out.extend_from_slice(attr_selector);
-            out.extend_from_slice(b"-s");
-        }
-        out.extend_from_slice(rest);
-    } else {
-        out.extend_from_slice(selector.as_bytes());
     }
 }
 

--- a/crates/vize_atelier_sfc/src/css/scoped/slotted.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped/slotted.rs
@@ -1,0 +1,69 @@
+use super::{push_deep_scope_prefix, trailing_combinator_start};
+use crate::css::scoped_selector::{find_top_level_pseudo, leading_universal_selector_end};
+use crate::css::transform::find_matching_paren;
+use vize_carton::Vec as ArenaVec;
+
+/// Transform :slotted() for slot content.
+pub(in crate::css) fn transform_slotted(
+    out: &mut ArenaVec<u8>,
+    selector: &str,
+    start: usize,
+    attr_selector: &[u8],
+) {
+    let before = &selector[..start];
+    let after = &selector[start + 9..];
+
+    if let Some(end) = find_matching_paren(after) {
+        let inner = &after[..end];
+        let rest = &after[end + 1..];
+
+        push_slotted_scope_prefix(out, before, attr_selector);
+        push_slotted_target(out, inner, attr_selector);
+        out.extend_from_slice(rest.as_bytes());
+    } else {
+        out.extend_from_slice(selector.as_bytes());
+    }
+}
+
+fn push_slotted_scope_prefix(out: &mut ArenaVec<u8>, before: &str, attr_selector: &[u8]) {
+    let before = before.trim_end();
+    if before.is_empty() {
+        return;
+    }
+
+    push_deep_scope_prefix(out, before, attr_selector);
+    if trailing_combinator_start(before).is_none() {
+        out.push(b' ');
+    }
+}
+
+fn push_slotted_target(out: &mut ArenaVec<u8>, inner: &str, attr_selector: &[u8]) {
+    let inner = inner.trim();
+    let inner = if let Some(end) = leading_universal_selector_end(inner) {
+        &inner[end..]
+    } else {
+        inner
+    };
+
+    if let Some(pseudo_pos) = find_top_level_pseudo(inner)
+        && !inner[..pseudo_pos].ends_with('\\')
+    {
+        out.extend_from_slice(&inner.as_bytes()[..pseudo_pos]);
+        push_slotted_attr(out, attr_selector);
+        out.extend_from_slice(&inner.as_bytes()[pseudo_pos..]);
+        return;
+    }
+
+    out.extend_from_slice(inner.as_bytes());
+    push_slotted_attr(out, attr_selector);
+}
+
+fn push_slotted_attr(out: &mut ArenaVec<u8>, attr_selector: &[u8]) {
+    if attr_selector.last() == Some(&b']') {
+        out.extend_from_slice(&attr_selector[..attr_selector.len() - 1]);
+        out.extend_from_slice(b"-s]");
+    } else {
+        out.extend_from_slice(attr_selector);
+        out.extend_from_slice(b"-s");
+    }
+}

--- a/crates/vize_atelier_sfc/src/css/tests/scoped_regressions.rs
+++ b/crates/vize_atelier_sfc/src/css/tests/scoped_regressions.rs
@@ -35,3 +35,21 @@ fn test_compile_scoped_css_scopes_parent_before_universal_pseudo() {
 
     assert_eq!(code, ".dialog__action-buttons[data-v-123]>:hover{flex:1;}");
 }
+
+#[test]
+fn test_compile_scoped_css_keeps_slotted_parent_combinator() {
+    let code = compile_scoped_css_without_whitespace(
+        ".card > :slotted(*) { flex: 1; }\
+         .card > :slotted(.title),\
+         .card > :slotted(.subtitle) { line-height: 1.2; }\
+         .card > :slotted(*):not(:last-child) { margin-bottom: 2px; }",
+    );
+
+    assert_eq!(
+        code,
+        ".card[data-v-123]>[data-v-123-s]{flex:1;}\
+         .card[data-v-123]>.title[data-v-123-s],\
+         .card[data-v-123]>.subtitle[data-v-123-s]{line-height:1.2;}\
+         .card[data-v-123]>[data-v-123-s]:not(:last-child){margin-bottom:2px;}"
+    );
+}

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -1,6 +1,8 @@
 use crate::css::scoped_selector::split_before_trailing_universal_or_pseudo;
 use vize_carton::{SmallVec, String};
 
+mod slotted;
+
 /// Scope CSS with the Vite plugin pipeline's selector model.
 pub(super) fn scope_css_for_pipeline(css: &str, scope_id: &str) -> String {
     transform_css_block(css, scope_id)
@@ -377,13 +379,7 @@ fn scope_selector(selector: &str, scope_id: &str) -> String {
     );
 
     if let Some(slotted) = find_pseudo_function_any(body.as_str(), &["::v-slotted(", ":slotted("]) {
-        let inner = &body[slotted.inner_start..slotted.inner_end];
-        let after = &body[slotted.end..];
-        let mut scoped = String::with_capacity(inner.len() + scope_id.len() + after.len() + 4);
-        scoped.push_str(inner);
-        push_slotted_scope_attr(&mut scoped, scope_id);
-        scoped.push_str(after);
-        body = scoped;
+        body = slotted::scope_slotted_selector(body.as_str(), &slotted, scope_id);
     } else if let Some(deep) =
         find_pseudo_function_any(body.as_str(), &["::v-deep(", "::deep(", ":deep("])
     {
@@ -663,12 +659,6 @@ fn push_scope_attr(output: &mut String, scope_id: &str) {
     output.push(']');
 }
 
-fn push_slotted_scope_attr(output: &mut String, scope_id: &str) {
-    output.push('[');
-    output.push_str(scope_id);
-    output.push_str("-s]");
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -712,30 +702,6 @@ mod tests {
         assert_eq!(
             unwrap_deep_selectors(css).as_str(),
             "[data-v-x] .parent > .child, [data-v-x] .slot, [data-v-x] .foo.bar {}"
-        );
-    }
-
-    #[test]
-    fn scopes_slotted_selectors_with_slotted_scope_id() {
-        assert_eq!(
-            scope_css_for_pipeline(":slotted(.foo) { color: red; }", "data-v-x").as_str(),
-            ".foo[data-v-x-s]{color: red;}"
-        );
-        assert_eq!(
-            scope_css_for_pipeline("::v-slotted(.foo) { color: red; }", "data-v-x").as_str(),
-            ".foo[data-v-x-s]{color: red;}"
-        );
-        assert_eq!(
-            scope_css_for_pipeline(":slotted(.foo):hover { color: red; }", "data-v-x").as_str(),
-            ".foo[data-v-x-s]:hover{color: red;}"
-        );
-    }
-
-    #[test]
-    fn scopes_nested_slotted_selector_with_slotted_scope_id() {
-        assert_eq!(
-            scope_css_for_pipeline(".host { :slotted(.foo) { color: red; } }", "data-v-x").as_str(),
-            " .foo[data-v-x-s]{color: red;}"
         );
     }
 

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs
@@ -1,0 +1,109 @@
+use super::{PseudoFunction, add_scope_before_trailing_combinator, find_scope_insert_position};
+use vize_carton::String;
+
+pub(super) fn scope_slotted_selector(
+    body: &str,
+    slotted: &PseudoFunction,
+    scope_id: &str,
+) -> String {
+    let before = body[..slotted.start].trim_end();
+    let inner = &body[slotted.inner_start..slotted.inner_end];
+    let after = &body[slotted.end..];
+    let mut scoped = String::with_capacity(body.len() + scope_id.len() * 2 + 4);
+
+    if !before.is_empty() {
+        let scoped_before = add_scope_before_trailing_combinator(before, scope_id);
+        scoped.push_str(scoped_before.as_str());
+        if !selector_ends_with_combinator(before) {
+            scoped.push(' ');
+        }
+    }
+
+    push_slotted_target(&mut scoped, inner, scope_id);
+    scoped.push_str(after);
+    scoped
+}
+
+fn selector_ends_with_combinator(selector: &str) -> bool {
+    let trimmed = selector.trim_end();
+    trimmed.ends_with('>') || trimmed.ends_with('+') || trimmed.ends_with('~')
+}
+
+fn push_slotted_target(output: &mut String, inner: &str, scope_id: &str) {
+    let target = strip_slotted_leading_universal(inner.trim());
+    let insert_at = find_scope_insert_position(target);
+    output.push_str(&target[..insert_at]);
+    push_slotted_scope_attr(output, scope_id);
+    output.push_str(&target[insert_at..]);
+}
+
+fn strip_slotted_leading_universal(selector: &str) -> &str {
+    let Some(end) = slotted_leading_universal_end(selector) else {
+        return selector;
+    };
+
+    &selector[end..]
+}
+
+fn slotted_leading_universal_end(selector: &str) -> Option<usize> {
+    let bytes = selector.as_bytes();
+    if bytes.first() == Some(&b'*') {
+        if bytes.get(1) == Some(&b'|') && bytes.get(2) == Some(&b'*') {
+            return Some(3);
+        }
+        return Some(1);
+    }
+
+    if bytes.first() == Some(&b'|') && bytes.get(1) == Some(&b'*') {
+        return Some(2);
+    }
+
+    None
+}
+
+fn push_slotted_scope_attr(output: &mut String, scope_id: &str) {
+    output.push('[');
+    output.push_str(scope_id);
+    output.push_str("-s]");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::scope_css_for_pipeline;
+
+    #[test]
+    fn scopes_slotted_selectors_with_slotted_scope_id() {
+        assert_eq!(
+            scope_css_for_pipeline(":slotted(.foo) { color: red; }", "data-v-x").as_str(),
+            ".foo[data-v-x-s]{color: red;}"
+        );
+        assert_eq!(
+            scope_css_for_pipeline("::v-slotted(.foo) { color: red; }", "data-v-x").as_str(),
+            ".foo[data-v-x-s]{color: red;}"
+        );
+        assert_eq!(
+            scope_css_for_pipeline(":slotted(.foo):hover { color: red; }", "data-v-x").as_str(),
+            ".foo[data-v-x-s]:hover{color: red;}"
+        );
+    }
+
+    #[test]
+    fn scopes_nested_slotted_selector_with_slotted_scope_id() {
+        assert_eq!(
+            scope_css_for_pipeline(".host { :slotted(.foo) { color: red; } }", "data-v-x").as_str(),
+            " .host[data-v-x] .foo[data-v-x-s]{color: red;}"
+        );
+    }
+
+    #[test]
+    fn scopes_nested_slotted_selectors_after_parent_combinators() {
+        assert_eq!(
+            scope_css_for_pipeline(
+                ".card { & > :slotted(*) { flex: 1; } & > :slotted(.title), & > :slotted(.subtitle) { line-height: 1.2; } & > :slotted(*):not(:last-child) { margin-bottom: 2px; } }",
+                "data-v-x"
+            )
+            .as_str(),
+            " .card[data-v-x] >[data-v-x-s]{flex: 1;} .card[data-v-x] >.title[data-v-x-s],.card[data-v-x] >.subtitle[data-v-x-s]{line-height: 1.2;} .card[data-v-x] >[data-v-x-s]:not(:last-child){margin-bottom: 2px;}"
+        );
+    }
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |          1133 |                   787 |               346 |             158 |     373 |            1006 |      658 |           558 |           697 |
+| Compiler                   |          1135 |                   787 |               348 |             158 |     373 |            1008 |      658 |           560 |           699 |
 | Linter                     |           358 |                   358 |                 0 |             298 |     301 |             719 |      238 |           387 |           567 |
 | Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           499 |           713 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          30 |              10 |       20 |
-| S0               |         946 |             495 |      451 |
+| S0               |         948 |             497 |      451 |
 | S1               |           5 |               1 |        4 |
 | S2               |          41 |              21 |       20 |
 | S1->S2           |         111 |              13 |       98 |
@@ -79,7 +79,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | `crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs:6` | source   | S0 2<br>raw OXC 15                                                                                   |    17 |
 | `crates/vize_atelier_core/src/steps/expression/prefix.rs:6`                  | source   | S0 1<br>Croquis analysis 1<br>raw OXC 14                                                             |    16 |
 
-Additional source/manifest rows are in the TSV: 324 omitted.
+Additional source/manifest rows are in the TSV: 326 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -762,7 +762,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css.rs	32	s0	S0	stage	viz
 compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser/engine_boundary.rs	37	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser/engine_boundary/value_guard.rs	23	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/css/scoped.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/css/scoped.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/css/scoped/slotted.rs	4	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css/tests.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css/transform.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/lib.rs	44	s0	S0	stage	vize_s0	preferred	1
@@ -856,6 +857,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/template_tests.rs	12	s0	S
 compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs	2	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/hmr.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/js_string.rs	1	s0	S0	stage	vize_carton	compat	1

--- a/davinci-road/plan/croquis-consumption.md
+++ b/davinci-road/plan/croquis-consumption.md
@@ -314,7 +314,7 @@ Items consumers import from `vize_croquis` that are outside the product set abov
 | `extract_identifiers_oxc`                    | `vize_canon`         |     5 |     5 |
 | `extract_identifiers_oxc`                    | `vize_maestro`       |     1 |     1 |
 | `extract_slot_props`                         | `vize_patina`        |     1 |     1 |
-| `find_matching_paren`                        | `vize_atelier_sfc`   |     1 |     1 |
+| `find_matching_paren`                        | `vize_atelier_sfc`   |     2 |     2 |
 | `generate_declaration_ts`                    | `vize_vitrine`       |     1 |     2 |
 | `generate_declaration_ts_with_split_scripts` | `vize_vitrine`       |     1 |     1 |
 | `generate_virtual_ts_with_croquis`           | `vize_patina`        |     1 |     1 |


### PR DESCRIPTION
## Summary
- preserve scoped parent selectors before `:slotted()` in the Vite CSS pipeline
- keep child combinators from CSS nesting when slotted rules are expanded
- share the safer slotted rewrite with the standalone scoped CSS path

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize_atelier_sfc slotted -- --nocapture`
- `cargo test -p vize_atelier_sfc scopes_nested_slotted -- --nocapture`
- `cargo test -p vize_atelier_sfc test_compile_scoped_css_keeps_slotted_parent_combinator -- --nocapture`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350`
- `git diff --check origin/main`

Fixes #6004

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791615588&installation_model_id=422833&pr_number=6010&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6010&signature=42bf8541c9479aa1fd37e53ca481cadec9b07181a61a463fb63e1d3bc7f4bef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scoped CSS handling for `:slotted()` and `::v-slotted()` selectors.
  - Fixed scoping for slotted selectors involving parent combinators, selector lists, nested selectors, universal selectors, and trailing `:not()` pseudo-classes.
  - Malformed slotted selectors are now preserved unchanged instead of being transformed incorrectly.
  - Added regression coverage to help ensure consistent generated scope attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->