### PR TITLE
fix(musea): allow skipped vrt cases in ci

### DIFF
--- a/npm/builder/vite-musea/src/cli/commands.test.ts
+++ b/npm/builder/vite-musea/src/cli/commands.test.ts
@@ -21,8 +21,8 @@ void test("VRT CI blocks on visual diffs", () => {
   assert.equal(hasCiBlockingVrtResult(summary({ failed: 1, passed: 0 })), true);
 });
 
-void test("VRT CI blocks on capture errors", () => {
-  assert.equal(hasCiBlockingVrtResult(summary({ skipped: 1, passed: 0 })), true);
+void test("VRT CI allows skipped variants", () => {
+  assert.equal(hasCiBlockingVrtResult(summary({ skipped: 1, passed: 0 })), false);
 });
 
 void test("VRT CI allows clean and newly-created baselines", () => {

--- a/npm/builder/vite-musea/src/cli/commands.ts
+++ b/npm/builder/vite-musea/src/cli/commands.ts
@@ -15,7 +15,7 @@ import type { ArtFileInfo } from "../types/index.js";
 import type { CliOptions } from "./index.js";
 
 export function hasCiBlockingVrtResult(summary: VrtSummary): boolean {
-  return summary.failed > 0 || summary.skipped > 0;
+  return summary.failed > 0;
 }
 
 export function isArtFileInput(filePath: string): boolean {
@@ -143,7 +143,7 @@ export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Prom
       console.log(`  HTML report: ${htmlPath}\n`);
     }
 
-    // CI mode - exit with error if visual diffs or capture/runtime errors occurred.
+    // CI mode - exit with error if visual diffs occurred.
     if (options.ci && hasCiBlockingVrtResult(summary)) {
       console.log("  CI mode: Exiting with error due to failures\n");
       process.exit(1);


### PR DESCRIPTION
## Summary
- make musea-vrt --ci fail only when visual diffs are present
- allow skipped variants to report in the summary without forcing a non-zero exit
- update the CLI command regression test for skipped-only summaries

## Verification
- node /Users/ubugeeei/.cache/node/corepack/v1/pnpm/12.1.0/bin/pnpm.mjs --dir npm/builder/vite-musea exec tsx --test src/cli/commands.test.ts
- git diff --check origin/main

Fixes #5994

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791616873&installation_model_id=422833&pr_number=6011&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6011&signature=a1ef10b0eedfc962a70055a85daf8bf643f61ff4cfab27901dbfc1d7d724ed60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skipped visual variants no longer block CI when no failures are detected.
  * CI failure reporting now focuses on visual differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->