### PR TITLE
fix(sfc): handle slotted column combinator

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -93,10 +93,8 @@ fn transform_css_block_with_parents(
 }
 
 fn should_recurse_at_rule(statement: &str) -> bool {
-    matches!(
-        statement.split_whitespace().next(),
-        Some("@container" | "@layer" | "@media" | "@supports")
-    )
+    ["@container", "@layer", "@media", "@supports"]
+        .contains(&statement.split_whitespace().next().unwrap_or(""))
 }
 
 fn find_rule_header_start(css: &str, start: usize, brace: usize) -> usize {
@@ -436,23 +434,20 @@ fn add_scope_before_trailing_combinator(selector: &str, scope_id: &str) -> Strin
     };
 
     let target = selector[..combinator_start].trim_end();
-    let suffix = &selector[target.len()..];
     let mut output = if target.is_empty() {
         scope_attr(scope_id)
     } else {
         add_scope_to_selector_end(target, scope_id)
     };
-    output.push_str(suffix);
+    output.push_str(&selector[target.len()..]);
     output
 }
 
 fn trailing_combinator_start(selector: &str) -> Option<usize> {
-    let bytes = selector.as_bytes();
-    match bytes.last().copied()? {
-        b'>' | b'+' | b'~' => Some(bytes.len() - 1),
-        b'|' if bytes.len() >= 2 && bytes[bytes.len() - 2] == b'|' => Some(bytes.len() - 2),
-        _ => None,
-    }
+    selector
+        .strip_suffix("||")
+        .or_else(|| selector.strip_suffix(['>', '+', '~']))
+        .map(str::len)
 }
 
 fn add_scope_to_selector_end(selector: &str, scope_id: &str) -> String {

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -430,12 +430,8 @@ fn split_leading_trivia(value: &str) -> (&str, &str) {
 }
 
 fn add_scope_before_trailing_combinator(selector: &str, scope_id: &str) -> String {
-    let Some((combinator_start, _)) = selector
-        .trim_end()
-        .char_indices()
-        .next_back()
-        .filter(|(_, char)| matches!(char, '>' | '+' | '~'))
-    else {
+    let trimmed = selector.trim_end();
+    let Some(combinator_start) = trailing_combinator_start(trimmed) else {
         return add_scope_to_selector_end(selector, scope_id);
     };
 
@@ -448,6 +444,15 @@ fn add_scope_before_trailing_combinator(selector: &str, scope_id: &str) -> Strin
     };
     output.push_str(suffix);
     output
+}
+
+fn trailing_combinator_start(selector: &str) -> Option<usize> {
+    let bytes = selector.as_bytes();
+    match bytes.last().copied()? {
+        b'>' | b'+' | b'~' => Some(bytes.len() - 1),
+        b'|' if bytes.len() >= 2 && bytes[bytes.len() - 2] == b'|' => Some(bytes.len() - 2),
+        _ => None,
+    }
 }
 
 fn add_scope_to_selector_end(selector: &str, scope_id: &str) -> String {

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs
@@ -1,4 +1,7 @@
-use super::{PseudoFunction, add_scope_before_trailing_combinator, find_scope_insert_position};
+use super::{
+    PseudoFunction, add_scope_before_trailing_combinator, find_scope_insert_position,
+    trailing_combinator_start,
+};
 use vize_carton::String;
 
 pub(super) fn scope_slotted_selector(
@@ -25,8 +28,7 @@ pub(super) fn scope_slotted_selector(
 }
 
 fn selector_ends_with_combinator(selector: &str) -> bool {
-    let trimmed = selector.trim_end();
-    trimmed.ends_with('>') || trimmed.ends_with('+') || trimmed.ends_with('~')
+    trailing_combinator_start(selector.trim_end()).is_some()
 }
 
 fn push_slotted_target(output: &mut String, inner: &str, scope_id: &str) {
@@ -104,6 +106,14 @@ mod tests {
             )
             .as_str(),
             " .card[data-v-x] >[data-v-x-s]{flex: 1;} .card[data-v-x] >.title[data-v-x-s],.card[data-v-x] >.subtitle[data-v-x-s]{line-height: 1.2;} .card[data-v-x] >[data-v-x-s]:not(:last-child){margin-bottom: 2px;}"
+        );
+        assert_eq!(
+            scope_css_for_pipeline(
+                ".card { & || :slotted(*) { display: table-cell; } }",
+                "data-v-x"
+            )
+            .as_str(),
+            " .card[data-v-x] ||[data-v-x-s]{display: table-cell;}"
         );
     }
 }

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -857,7 +857,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/template_tests.rs	12	s0	S
 compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs	2	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/hmr.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/js_string.rs	1	s0	S0	stage	vize_carton	compat	1


### PR DESCRIPTION
Refs #6004.

## Summary
- treat the CSS column combinator (`||`) as a trailing combinator when injecting scoped ids
- cover nested `:slotted(*)` selectors that follow `& ||`
- refresh the Davinci migration surface inventory

## Verification
- cargo fmt --all --check
- cargo test -p vize_atelier_sfc scopes_nested_slotted_selectors_after_parent_combinators -- --nocapture
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791617449&installation_model_id=422833&pr_number=6012&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6012&signature=0335af23d43343ce87bee94cd2a2d9082b5176caeda2050cbfd9670a40157bd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->