### PR TITLE
fix(glyph): keep art multiline attributes idempotent

### DIFF
--- a/crates/vize_glyph/src/formatter/custom_block.rs
+++ b/crates/vize_glyph/src/formatter/custom_block.rs
@@ -90,11 +90,12 @@ fn write_art_chunk(
 ) -> Result<(), FormatError> {
     let chunk = lines.join("\n");
     let formatted = crate::template::format_template_content(chunk.trim(), options)?;
-    let indent = options.indent_bytes();
-    for line in formatted.lines() {
-        output.extend_from_slice(indent);
-        output.extend_from_slice(line.as_bytes());
-        output.extend_from_slice(options.newline_bytes());
-    }
+    let trimmed = formatted.trim_end_matches('\n').trim_end_matches('\r');
+    super::template_indent::write_indented_template(
+        output,
+        trimmed,
+        options.indent_bytes(),
+        options.newline_bytes(),
+    );
     Ok(())
 }

--- a/crates/vize_glyph/tests/custom_blocks.rs
+++ b/crates/vize_glyph/tests/custom_blocks.rs
@@ -63,3 +63,30 @@ fn art_block_preserves_blank_lines_between_variants() {
     );
     assert_eq!(first.code, second.code);
 }
+
+#[test]
+fn art_block_multiline_attribute_values_are_idempotent() {
+    let source = r#"<art>
+  <section>
+    <div
+      style="
+        height: 100%;
+        display: flex;
+      "
+    >
+      hello
+    </div>
+  </section>
+</art>
+"#;
+
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+    let third = format_sfc(&second.code, &options).unwrap();
+
+    assert!(first.code.contains("\n        height: 100%;\n"));
+    assert!(!first.code.contains("\n          height: 100%;\n"));
+    assert_eq!(first.code, second.code);
+    assert_eq!(second.code, third.code);
+}

--- a/crates/vize_glyph/tests/custom_blocks.rs
+++ b/crates/vize_glyph/tests/custom_blocks.rs
@@ -85,8 +85,22 @@ fn art_block_multiline_attribute_values_are_idempotent() {
     let second = format_sfc(&first.code, &options).unwrap();
     let third = format_sfc(&second.code, &options).unwrap();
 
-    assert!(first.code.contains("\n        height: 100%;\n"));
-    assert!(!first.code.contains("\n          height: 100%;\n"));
+    assert_eq!(
+        first.code.as_str(),
+        r#"<art>
+  <section>
+    <div
+      style="
+        height: 100%;
+        display: flex;
+      "
+    >
+      hello
+    </div>
+  </section>
+</art>
+"#
+    );
     assert_eq!(first.code, second.code);
     assert_eq!(second.code, third.code);
 }


### PR DESCRIPTION
Fixes #5993.

## Summary
- reuse template indentation masking when formatting Musea `<art>` chunks
- prevent multiline attribute continuation lines from gaining indentation on repeated runs
- add a regression that formats the issue shape three times

## Verification
- cargo fmt --all --check
- cargo test -p vize_glyph art_block -- --nocapture
- cargo test -p vize_glyph test_format_sfc_multiline_attribute_value_is_idempotent -- --nocapture
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791617694&installation_model_id=422833&pr_number=6013&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6013&signature=7215e6536de4d2c9cabb22e92cd6c409b6ddb8b04c4b37f6eea91517ee25eb0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->