### PR TITLE
fix(canon): avoid self-linking package mirrors

### DIFF
--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -95,6 +95,10 @@ pub(super) fn symlink_package_dir(source: &Path, target: &Path) -> std::io::Resu
 }
 
 fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if path_already_is_source(source, target)? {
+        return Ok(());
+    }
+
     if symlink_matches(source, target)? {
         return Ok(());
     }
@@ -121,6 +125,17 @@ fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
         } else {
             std::os::windows::fs::symlink_file(source, target)
         }
+    }
+}
+
+fn path_already_is_source(source: &Path, target: &Path) -> std::io::Result<bool> {
+    if source == target {
+        return Ok(true);
+    }
+    match std::fs::symlink_metadata(target) {
+        Ok(_) => Ok(package_link_source(source) == package_link_source(target)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
     }
 }
 

--- a/crates/vize_canon/src/batch/runtime_deps/tests.rs
+++ b/crates/vize_canon/src/batch/runtime_deps/tests.rs
@@ -1,11 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use super::materialize_runtime_dependencies;
 use super::resolver::{
     VueRuntimePackages, resolve_package, resolve_vue_package, resolve_vue_runtime_packages,
     with_test_env_overrides,
 };
 use super::stubs::VUE_RUNTIME_CORE_STUB_TYPES;
+use super::{materialize_runtime_dependencies, symlink_package_dir};
 
 #[test]
 fn explicit_runtime_packages_override_project_packages() {
@@ -194,6 +194,35 @@ fn materialized_runtime_dom_writes_runtime_core_stub_when_core_is_absent() {
                 VUE_RUNTIME_CORE_STUB_TYPES
             );
         },
+    );
+}
+
+#[test]
+fn package_dir_link_leaves_self_targets_untouched() {
+    let temp = tempfile::tempdir().unwrap();
+    let node_modules = temp.path().join("node_modules");
+    std::fs::create_dir_all(node_modules.join(".pnpm/pkg@1.0.0/node_modules/pkg")).unwrap();
+    std::fs::create_dir_all(node_modules.join(".bin")).unwrap();
+    std::fs::write(node_modules.join(".modules.yaml"), "layout: isolated\n").unwrap();
+
+    symlink_package_dir(&node_modules, &node_modules).unwrap();
+
+    assert!(node_modules.is_dir());
+    assert!(
+        !std::fs::symlink_metadata(&node_modules)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert!(node_modules.join(".bin").is_dir());
+    assert!(
+        node_modules
+            .join(".pnpm/pkg@1.0.0/node_modules/pkg")
+            .is_dir()
+    );
+    assert_eq!(
+        std::fs::read_to_string(node_modules.join(".modules.yaml")).unwrap(),
+        "layout: isolated\n"
     );
 }
 


### PR DESCRIPTION
Fixes #5991.

## Summary
- skip package mirror symlink materialization when the target already resolves to the source
- prevent a collapsed mirror path from replacing a real `node_modules` directory with a self-referential symlink
- add a regression that preserves `.bin`, `.pnpm`, and `.modules.yaml` for a self-targeted install

## Verification
- cargo fmt --all --check
- cargo test -p vize_canon package_dir_link_leaves_self_targets_untouched -- --nocapture
- cargo test -p vize_canon materialize_ -- --nocapture
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791618374&installation_model_id=422833&pr_number=6014&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6014&signature=0c88241294b47c71b2c9e85fde238802744d7b10e7db65d2870fd53b31312d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->