### PR TITLE
fix(sfc): rewrite legacy deep combinators

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -1,6 +1,7 @@
 use crate::css::scoped_selector::split_before_trailing_universal_or_pseudo;
 use vize_carton::{SmallVec, String};
 
+mod legacy_deep;
 mod slotted;
 
 /// Scope CSS with the Vite plugin pipeline's selector model.
@@ -371,10 +372,7 @@ fn scope_selector(selector: &str, scope_id: &str) -> String {
     let leading = &selector[..leading_length];
     let body_end = trailing_trim_end(selector);
     let trailing = &selector[body_end..];
-    let mut body = unwrap_pseudo_functions(
-        &selector[leading_length..body_end],
-        &["::v-global(", ":global("],
-    );
+    let mut body = legacy_deep::normalize_scoped_selector_body(&selector[leading_length..body_end]);
 
     if let Some(slotted) = find_pseudo_function_any(body.as_str(), &["::v-slotted(", ":slotted("]) {
         body = slotted::scope_slotted_selector(body.as_str(), &slotted, scope_id);

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope/legacy_deep.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope/legacy_deep.rs
@@ -1,0 +1,211 @@
+use vize_carton::String;
+
+use super::find_matching_paren;
+
+pub(super) fn normalize_scoped_selector_body(selector: &str) -> String {
+    let selector = super::unwrap_pseudo_functions(selector, &["::v-global(", ":global("]);
+    normalize(selector.as_str())
+}
+
+fn normalize(selector: &str) -> String {
+    let Some(marker) = find_marker_from(selector, 0) else {
+        return String::from(selector);
+    };
+
+    let before = selector[..marker.start].trim_end();
+    let after = selector[marker.end..].trim_start();
+    let target = deep_target(after).unwrap_or_else(|| String::from(after));
+    let target = strip_legacy_markers(target.as_str());
+
+    let mut output = String::with_capacity(selector.len() + 8);
+    output.push_str(before);
+    if !before.is_empty() {
+        output.push(' ');
+    }
+    output.push_str(":deep(");
+    output.push_str(target.as_str());
+    output.push(')');
+
+    output
+}
+
+fn deep_target(after: &str) -> Option<String> {
+    if !after.starts_with('(') {
+        return None;
+    }
+
+    let end = find_matching_paren(after, 0)?;
+    let mut target = String::with_capacity(after.len().saturating_sub(2));
+    target.push_str(&after[1..end]);
+    target.push_str(&after[end + 1..]);
+    Some(target)
+}
+
+fn strip_legacy_markers(selector: &str) -> String {
+    let mut output = String::with_capacity(selector.len());
+    let mut cursor = 0usize;
+    let mut changed = false;
+
+    while let Some(marker) = find_marker_from(selector, cursor) {
+        output.push_str(selector[cursor..marker.start].trim_end());
+        push_descendant_space(&mut output);
+        cursor = skip_ws(selector, marker.end);
+        changed = true;
+    }
+
+    if !changed {
+        return String::from(selector);
+    }
+
+    output.push_str(&selector[cursor..]);
+    output
+}
+
+fn push_descendant_space(output: &mut String) {
+    if !output.is_empty()
+        && output
+            .chars()
+            .next_back()
+            .is_some_and(|char| !char.is_whitespace())
+    {
+        output.push(' ');
+    }
+}
+
+fn skip_ws(input: &str, cursor: usize) -> usize {
+    input[cursor..]
+        .char_indices()
+        .find(|(_, char)| !char.is_whitespace())
+        .map_or(input.len(), |(index, _)| cursor + index)
+}
+
+struct Marker {
+    start: usize,
+    end: usize,
+}
+
+fn find_marker_from(selector: &str, cursor: usize) -> Option<Marker> {
+    let mut scanner = Scanner::new(selector, cursor);
+
+    while let Some(index) = scanner.next_syntax_index() {
+        if let Some(marker) = marker_at(selector, index) {
+            return Some(marker);
+        }
+    }
+
+    None
+}
+
+fn marker_at(selector: &str, index: usize) -> Option<Marker> {
+    for marker in [">>>", "/deep/", "::v-deep"] {
+        if selector[index..].starts_with(marker)
+            && has_marker_boundary(selector, index + marker.len())
+        {
+            return Some(Marker {
+                start: index,
+                end: index + marker.len(),
+            });
+        }
+    }
+
+    None
+}
+
+fn has_marker_boundary(selector: &str, index: usize) -> bool {
+    selector[index..]
+        .chars()
+        .next()
+        .is_none_or(|char| !matches!(char, '-' | '_' | 'a'..='z' | 'A'..='Z' | '0'..='9'))
+}
+
+struct Scanner<'a> {
+    selector: &'a str,
+    cursor: usize,
+    quote: Option<u8>,
+    bracket_depth: usize,
+    in_comment: bool,
+}
+
+impl<'a> Scanner<'a> {
+    fn new(selector: &'a str, cursor: usize) -> Self {
+        Self {
+            selector,
+            cursor,
+            quote: None,
+            bracket_depth: 0,
+            in_comment: false,
+        }
+    }
+
+    fn next_syntax_index(&mut self) -> Option<usize> {
+        while self.cursor < self.selector.len() {
+            let index = self.cursor;
+            let bytes = self.selector.as_bytes();
+            let byte = bytes[index];
+            let next = bytes.get(index + 1).copied();
+
+            if self.in_comment {
+                self.cursor += 1;
+                if byte == b'*' && next == Some(b'/') {
+                    self.cursor += 1;
+                    self.in_comment = false;
+                }
+                continue;
+            }
+
+            if let Some(quote) = self.quote {
+                self.cursor += if byte == b'\\' && next.is_some() {
+                    2
+                } else {
+                    1
+                };
+                if byte == quote {
+                    self.quote = None;
+                }
+                continue;
+            }
+
+            match byte {
+                b'\\' => {
+                    self.cursor += if next.is_some() { 2 } else { 1 };
+                }
+                b'/' if next == Some(b'*') => {
+                    self.cursor += 2;
+                    self.in_comment = true;
+                }
+                b'\'' | b'"' => {
+                    self.cursor += 1;
+                    self.quote = Some(byte);
+                }
+                b'[' => {
+                    self.cursor += 1;
+                    self.bracket_depth += 1;
+                }
+                b']' => {
+                    self.cursor += 1;
+                    self.bracket_depth = self.bracket_depth.saturating_sub(1);
+                }
+                _ => {
+                    self.cursor += byte_char_len(byte);
+                    if self.bracket_depth == 0 {
+                        return Some(index);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
+fn byte_char_len(byte: u8) -> usize {
+    if byte < 0x80 {
+        1
+    } else if byte < 0xE0 {
+        2
+    } else if byte < 0xF0 {
+        3
+    } else {
+        4
+    }
+}

--- a/crates/vize_atelier_sfc/tests/vite_css_scope.rs
+++ b/crates/vize_atelier_sfc/tests/vite_css_scope.rs
@@ -11,3 +11,16 @@ fn vite_pipeline_scopes_parent_before_trailing_universal_selectors() {
         ".dialog__action-buttons[data-v-x]>*:hover{flex: 1;}"
     );
 }
+
+#[test]
+fn vite_pipeline_rewrites_legacy_deep_combinators() {
+    let output = scope_css_for_pipeline(
+        ".panel >>> .inner >>> .leaf { padding: 0; }.panel ::v-deep .other /deep/ .child { margin: 0; }[data-label=\">>>\"] .plain { color: red; }.panel[data-token=\"::v-deep\"] { color: blue; }.literal\\>\\>\\> .plain { color: green; }",
+        "data-v-x",
+    );
+
+    assert_eq!(
+        output.as_str(),
+        ".panel[data-v-x] .inner .leaf{padding: 0;}.panel[data-v-x] .other .child{margin: 0;}[data-label=\">>>\"] .plain[data-v-x]{color: red;}.panel[data-token=\"::v-deep\"][data-v-x]{color: blue;}.literal\\>\\>\\> .plain[data-v-x]{color: green;}"
+    );
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |          1135 |                   787 |               348 |             158 |     373 |            1008 |      658 |           560 |           699 |
+| Compiler                   |          1136 |                   787 |               349 |             158 |     373 |            1009 |      658 |           561 |           700 |
 | Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           568 |
 | Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           500 |           715 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          30 |              10 |       20 |
-| S0               |         948 |             497 |      451 |
+| S0               |         949 |             498 |      451 |
 | S1               |           5 |               1 |        4 |
 | S2               |          41 |              21 |       20 |
 | S1->S2           |         111 |              13 |       98 |
@@ -79,7 +79,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | `crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs:6` | source   | S0 2<br>raw OXC 15                                                                                   |    17 |
 | `crates/vize_atelier_core/src/steps/expression/prefix.rs:6`                  | source   | S0 1<br>Croquis analysis 1<br>raw OXC 14                                                             |    16 |
 
-Additional source/manifest rows are in the TSV: 326 omitted.
+Additional source/manifest rows are in the TSV: 327 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -857,6 +857,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/template_tests.rs	12	s0	S
 compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope/legacy_deep.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope/slotted.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/hmr.rs	1	s0	S0	stage	vize_carton	compat	1


### PR DESCRIPTION
Fixes #6007.

## Summary
- normalize legacy scoped deep combinators before the existing :deep(...) scoping path
- cover >>>, ::v-deep, and /deep/ so the generated CSS scopes the parent selector and emits no legacy tokens

## Verification
- cargo fmt --all --check
- cargo test -p vize_atelier_sfc vite_pipeline_rewrites_legacy_deep_combinators -- --nocapture
- cargo test -p vize_atelier_sfc vite_plugin::css_scope -- --nocapture
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791619991&installation_model_id=422833&pr_number=6016&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6016&signature=7504b43cc0196a6c7f774a433858e0de982f064739a9bf5ff4f40589274c8e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSS scoping compatibility for legacy deep-selector syntax, including `>>>`, `/deep/`, `::v-deep`, and `::deep`.
  - Legacy selectors are now rewritten into supported deep-selector behavior while preserving surrounding selector structure.
  - Added coverage to verify legacy syntax is transformed correctly and does not remain in scoped output.
  - Improved handling of legacy deep selectors within more complex selector expressions, including functional forms and nested structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->