### PR TITLE
feat(musea-vrt): capture variants concurrently

### DIFF
--- a/npm/builder/vite-musea/src/cli/commands.test.ts
+++ b/npm/builder/vite-musea/src/cli/commands.test.ts
@@ -42,6 +42,16 @@ void test("CLI threshold accepts zero as an explicit threshold", () => {
   assert.equal(options.thresholdProvided, true);
 });
 
+void test("CLI workers accepts positive concurrency and clamps invalid values", () => {
+  const concurrent = parseArgs(["--workers", "8"]);
+  assert.equal(concurrent.workers, 8);
+  assert.equal(concurrent.workersProvided, true);
+
+  const invalid = parseArgs(["-w", "0"]);
+  assert.equal(invalid.workers, 1);
+  assert.equal(invalid.workersProvided, true);
+});
+
 void test("CLI VRT options preserve config threshold when CLI threshold is omitted", () => {
   const options = parseArgs([]);
   options.vrt = {
@@ -49,6 +59,7 @@ void test("CLI VRT options preserve config threshold when CLI threshold is omitt
     capture: { settleTime: 250 },
     comparison: { antiAliasing: false },
     viewports: [{ width: 320, height: 240, name: "tiny" }],
+    workers: 4,
   };
 
   assert.deepEqual(createVrtOptions(options), {
@@ -57,19 +68,22 @@ void test("CLI VRT options preserve config threshold when CLI threshold is omitt
     capture: { settleTime: 250 },
     comparison: { antiAliasing: false },
     viewports: [{ width: 320, height: 240, name: "tiny" }],
+    workers: 4,
   });
 });
 
 void test("CLI threshold overrides configured VRT threshold", () => {
-  const options = parseArgs(["--threshold", "0"]);
+  const options = parseArgs(["--threshold", "0", "--workers", "8"]);
   options.vrt = {
     threshold: 10,
+    workers: 2,
     comparison: { antiAliasing: false },
   };
 
   assert.deepEqual(createVrtOptions(options), {
     snapshotDir: ".vize/snapshots",
     threshold: 0,
+    workers: 8,
     comparison: { antiAliasing: false },
   });
 });

--- a/npm/builder/vite-musea/src/cli/commands.ts
+++ b/npm/builder/vite-musea/src/cli/commands.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 
 import { MuseaVrtRunner, generateVrtReport, generateVrtJsonReport } from "../vrt.js";
 import type { ExtendedVrtOptions, VrtSummary } from "../vrt.js";
+import { normalizeVrtWorkerCount } from "../vrt.js";
 import type { ArtFileInfo } from "../types/index.js";
 
 import type { CliOptions } from "./index.js";
@@ -24,13 +25,18 @@ export function isArtFileInput(filePath: string): boolean {
 
 export function createVrtOptions(options: CliOptions): ExtendedVrtOptions {
   const configured = options.vrt ?? {};
-  return {
+  const vrtOptions: ExtendedVrtOptions = {
     ...configured,
     snapshotDir: path.join(options.output, "snapshots"),
     threshold: options.thresholdProvided
       ? options.threshold
       : (configured.threshold ?? options.threshold),
   };
+  const workers = options.workersProvided ? options.workers : configured.workers;
+  if (workers !== undefined) {
+    vrtOptions.workers = normalizeVrtWorkerCount(workers);
+  }
+  return vrtOptions;
 }
 
 export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Promise<void> {

--- a/npm/builder/vite-musea/src/cli/index.ts
+++ b/npm/builder/vite-musea/src/cli/index.ts
@@ -15,6 +15,7 @@
  *   -c, --config     Path to vite config (default: vite.config.ts)
  *   -o, --output     Output directory for reports (default: .vize)
  *   -t, --threshold  Diff threshold percentage (default: 0.1)
+ *   -w, --workers    Number of concurrent captures (default: 1)
  *   --json           Output JSON report instead of HTML
  *   --ci             CI mode - exit with non-zero code on failures
  *   --a11y           Run accessibility audits alongside VRT
@@ -38,6 +39,8 @@ export interface CliOptions {
   output: string;
   threshold: number;
   thresholdProvided: boolean;
+  workers: number;
+  workersProvided: boolean;
   json: boolean;
   ci: boolean;
   a11y: boolean;
@@ -56,6 +59,8 @@ export function parseArgs(args: string[]): CliOptions {
     output: ".vize",
     threshold: 0.1,
     thresholdProvided: false,
+    workers: 1,
+    workersProvided: false,
     json: false,
     ci: false,
     a11y: false,
@@ -110,6 +115,11 @@ export function parseArgs(args: string[]): CliOptions {
         options.threshold = parseThreshold(args[++i]);
         options.thresholdProvided = true;
         break;
+      case "-w":
+      case "--workers":
+        options.workers = parseWorkers(args[++i]);
+        options.workersProvided = true;
+        break;
       case "--json":
         options.json = true;
         break;
@@ -138,6 +148,11 @@ function parseThreshold(value: string | undefined): number {
   return Number.isFinite(threshold) ? threshold : 0.1;
 }
 
+function parseWorkers(value: string | undefined): number {
+  const workers = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(workers) ? Math.max(1, workers) : 1;
+}
+
 function printHelp(): void {
   console.log(`
 Musea VRT - Visual Regression Testing for Component Gallery
@@ -158,6 +173,7 @@ Options:
   -o, --output <dir>   Output directory for reports (default: .vize)
   -t, --threshold <n>  Diff threshold percentage (default: 0.1)
   -b, --base-url <url> Base URL for dev server (default: http://localhost:5173)
+  -w, --workers <n>    Number of concurrent captures (default: 1)
   --json               Output JSON report instead of HTML
   --ci                 CI mode - exit with non-zero code on failures
   --a11y               Run accessibility audits alongside VRT
@@ -178,6 +194,9 @@ Examples:
 
   # Run with accessibility audits
   musea-vrt --a11y
+
+  # Capture variants concurrently
+  musea-vrt --workers 8
 
   # Approve all failed snapshots
   musea-vrt approve

--- a/npm/builder/vite-musea/src/types/vrt.ts
+++ b/npm/builder/vite-musea/src/types/vrt.ts
@@ -33,6 +33,12 @@ export interface VrtOptions {
    * @default [{ width: 1280, height: 720 }, { width: 375, height: 667 }]
    */
   viewports?: ViewportConfig[];
+
+  /**
+   * Number of variants/viewports to capture concurrently.
+   * @default 1
+   */
+  workers?: number;
 }
 
 /**

--- a/npm/builder/vite-musea/src/vrt.ts
+++ b/npm/builder/vite-musea/src/vrt.ts
@@ -7,6 +7,7 @@
 
 export {
   MuseaVrtRunner,
+  normalizeVrtWorkerCount,
   type VrtResult,
   type VrtSummary,
   type ExtendedVrtOptions,

--- a/npm/builder/vite-musea/src/vrt/runner.test.ts
+++ b/npm/builder/vite-musea/src/vrt/runner.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ArtFileInfo, ViewportConfig } from "../types/index.ts";
+import { MuseaVrtRunner, normalizeVrtWorkerCount } from "./runner.ts";
+import type { VrtResult } from "./types.ts";
+
+void test("worker count is normalized to a positive integer", () => {
+  assert.equal(normalizeVrtWorkerCount(undefined), 1);
+  assert.equal(normalizeVrtWorkerCount(0), 1);
+  assert.equal(normalizeVrtWorkerCount(-2), 1);
+  assert.equal(normalizeVrtWorkerCount(Number.NaN), 1);
+  assert.equal(normalizeVrtWorkerCount(2.9), 2);
+});
+
+void test("runAllTests captures variants concurrently while preserving result order", async () => {
+  const runner = new StubVrtRunner({ workers: 2, viewports: [{ width: 320, height: 240 }] });
+  runner.markInitialized();
+
+  const results = await runner.runAllTests(
+    [art("Button.art.vue", ["primary", "secondary", "disabled"]), art("Badge.art.vue", ["info"])],
+    "http://localhost:5173",
+  );
+
+  assert.equal(runner.maxActiveCaptures, 2);
+  assert.deepEqual(
+    results.map((result) => `${result.artPath}:${result.variantName}`),
+    [
+      "Button.art.vue:primary",
+      "Button.art.vue:secondary",
+      "Button.art.vue:disabled",
+      "Badge.art.vue:info",
+    ],
+  );
+});
+
+class StubVrtRunner extends MuseaVrtRunner {
+  activeCaptures = 0;
+  maxActiveCaptures = 0;
+
+  markInitialized(): void {
+    (this as unknown as { browser: unknown }).browser = {};
+  }
+
+  override async captureAndCompare(
+    artFile: ArtFileInfo,
+    variantName: string,
+    viewport: ViewportConfig,
+  ): Promise<VrtResult> {
+    this.activeCaptures++;
+    this.maxActiveCaptures = Math.max(this.maxActiveCaptures, this.activeCaptures);
+    await new Promise((resolve) => setTimeout(resolve, variantName === "primary" ? 30 : 1));
+    this.activeCaptures--;
+
+    return {
+      artPath: artFile.path,
+      variantName,
+      viewport,
+      passed: true,
+      snapshotPath: `${artFile.path}-${variantName}.png`,
+    };
+  }
+}
+
+function art(path: string, variants: string[]): ArtFileInfo {
+  return {
+    path,
+    metadata: {
+      title: path,
+      tags: [],
+      status: "ready",
+    },
+    variants: variants.map((name) => ({
+      name,
+      template: `<div>${name}</div>`,
+      isDefault: false,
+      skipVrt: false,
+    })),
+    hasScriptSetup: false,
+    hasScript: false,
+    styleCount: 0,
+  };
+}

--- a/npm/builder/vite-musea/src/vrt/runner.ts
+++ b/npm/builder/vite-musea/src/vrt/runner.ts
@@ -25,6 +25,12 @@ export type { VrtResult, VrtSummary, ExtendedVrtOptions, PixelCompareOptions } f
 
 import type { VrtResult, VrtSummary, ExtendedVrtOptions } from "./types.js";
 
+type VrtJob = {
+  art: ArtFileInfo;
+  variantName: string;
+  viewport: ViewportConfig;
+};
+
 /**
  * VRT runner using Playwright.
  */
@@ -44,6 +50,7 @@ export class MuseaVrtRunner {
         { width: 1280, height: 720, name: "desktop" },
         { width: 375, height: 667, name: "mobile" },
       ],
+      workers: normalizeVrtWorkerCount(options.workers),
     };
     this.capture = {
       fullPage: options.capture?.fullPage ?? false,
@@ -120,45 +127,28 @@ export class MuseaVrtRunner {
       throw new Error("VRT runner not initialized. Call init() first.");
     }
 
-    const results: VrtResult[] = [];
     const retries = this.ci.retries ?? 0;
+    const jobs = createVrtJobs(artFiles, this.options.viewports);
 
-    for (const art of artFiles) {
-      for (const variant of art.variants) {
-        if (variant.skipVrt) {
-          continue;
+    return runJobsWithWorkers(jobs, this.options.workers, async (job) => {
+      let result: VrtResult | null = null;
+      let attempts = 0;
+
+      while (attempts <= retries) {
+        result = await this.captureAndCompare(job.art, job.variantName, job.viewport, baseUrl);
+        if (result.passed || result.isNew || !result.error) {
+          break;
         }
-
-        // Determine viewports: use per-variant viewport if defined, else global viewports
-        const viewports = variant.args?.viewport
-          ? [variant.args.viewport as ViewportConfig]
-          : this.options.viewports;
-
-        for (const viewport of viewports) {
-          let result: VrtResult | null = null;
-          let attempts = 0;
-
-          while (attempts <= retries) {
-            result = await this.captureAndCompare(art, variant.name, viewport, baseUrl);
-            if (result.passed || result.isNew || !result.error) {
-              break;
-            }
-            attempts++;
-            if (attempts <= retries) {
-              console.log(
-                `[vrt] Retry ${attempts}/${retries}: ${path.basename(art.path)}/${variant.name}`,
-              );
-            }
-          }
-
-          if (result) {
-            results.push(result);
-          }
+        attempts++;
+        if (attempts <= retries) {
+          console.log(
+            `[vrt] Retry ${attempts}/${retries}: ${path.basename(job.art.path)}/${job.variantName}`,
+          );
         }
       }
-    }
 
-    return results;
+      return result;
+    });
   }
 
   /**
@@ -280,4 +270,55 @@ export class MuseaVrtRunner {
   getSummary(results: VrtResult[]): VrtSummary {
     return computeSummary(results, this.startTime);
   }
+}
+
+export function normalizeVrtWorkerCount(workers: number | undefined): number {
+  if (workers === undefined || !Number.isFinite(workers)) {
+    return 1;
+  }
+  return Math.max(1, Math.floor(workers));
+}
+
+function createVrtJobs(artFiles: ArtFileInfo[], defaultViewports: ViewportConfig[]): VrtJob[] {
+  const jobs: VrtJob[] = [];
+  for (const art of artFiles) {
+    for (const variant of art.variants) {
+      if (variant.skipVrt) {
+        continue;
+      }
+
+      const viewports = variant.args?.viewport
+        ? [variant.args.viewport as ViewportConfig]
+        : defaultViewports;
+
+      for (const viewport of viewports) {
+        jobs.push({ art, variantName: variant.name, viewport });
+      }
+    }
+  }
+  return jobs;
+}
+
+async function runJobsWithWorkers<T>(
+  jobs: readonly VrtJob[],
+  workerCount: number,
+  runJob: (job: VrtJob) => Promise<T | null>,
+): Promise<T[]> {
+  const results = Array.from<T | null>({ length: jobs.length }, () => null);
+  let nextJobIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      const jobIndex = nextJobIndex++;
+      const job = jobs[jobIndex];
+      if (!job) {
+        return;
+      }
+      results[jobIndex] = await runJob(job);
+    }
+  }
+
+  const activeWorkers = Math.min(normalizeVrtWorkerCount(workerCount), jobs.length);
+  await Promise.all(Array.from({ length: activeWorkers }, () => runWorker()));
+  return results.filter((result): result is T => result !== null);
 }


### PR DESCRIPTION
## Summary
- add a `workers` VRT option and `--workers/-w` CLI flag
- run VRT captures with bounded concurrency while preserving deterministic result order
- cover worker normalization and CLI override behavior

## Verification
- `node /Users/ubugeeei/.cache/node/corepack/v1/pnpm/12.1.0/bin/pnpm.mjs --dir npm/builder/vite-musea exec tsx --test src/cli/commands.test.ts src/vrt/runner.test.ts`
- `VIZE_ALLOW_NATIVE_VERSION_MISMATCH=1 node /Users/ubugeeei/.cache/node/corepack/v1/pnpm/12.1.0/bin/pnpm.mjs --dir npm/builder/vite-musea exec tsx --test 'src/*.test.ts' 'src/**/*.test.ts'`\n- `node /Users/ubugeeei/.cache/node/corepack/v1/pnpm/12.1.0/bin/pnpm.mjs --dir npm/builder/vite-musea check`\n- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`\n- `git diff --check origin/main`\n\nCloses #5983

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791622567&installation_model_id=422833&pr_number=6017&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6017&signature=0bed8cb18fc9c69219c35156c355f16c2a9895803b4f999d5b1e9151ead82581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->