### PR TITLE
fix(patina): clarify prop-driven style policy

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -38,6 +38,7 @@ mod no_unused_components;
 mod nuxt;
 mod nuxt_config_order;
 mod nuxt_prefer_nuxt_link;
+mod prop_style_policy;
 mod recovered_parse_analysis;
 mod script;
 mod severity_overrides;

--- a/crates/vize_patina/src/linter/tests/prop_style_policy.rs
+++ b/crates/vize_patina/src/linter/tests/prop_style_policy.rs
@@ -1,0 +1,43 @@
+use super::{LintPreset, Linter};
+
+#[test]
+fn opinionated_allows_prop_driven_inline_style() {
+    let linter = Linter::with_preset(LintPreset::Opinionated).with_enabled_rules(Some(vec![
+        "vue/no-inline-style".into(),
+        "css/no-v-bind-performance".into(),
+    ]));
+    let inline_style = r#"<template>
+  <span :class="['icon', `icon-${size}`]" :style="color ? { color } : undefined" />
+</template>
+"#;
+
+    let inline_result = linter.lint_sfc(inline_style, "Icon.vue");
+    assert_eq!(
+        inline_result
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.rule_name)
+            .collect::<Vec<_>>(),
+        Vec::<&str>::new()
+    );
+
+    let css_v_bind = r#"<template><span class="icon" /></template>
+<style scoped>
+.icon {
+  color: v-bind("color ?? 'inherit'");
+}
+</style>
+"#;
+    let css_result = linter.lint_sfc(css_v_bind, "Icon.vue");
+    assert_eq!(
+        css_result
+            .diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.rule_name, diagnostic.message.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(
+            "css/no-v-bind-performance",
+            "v-bind() installs runtime CSS variable updates"
+        )]
+    );
+}

--- a/crates/vize_patina/src/rules/css/no_v_bind_performance.rs
+++ b/crates/vize_patina/src/rules/css/no_v_bind_performance.rs
@@ -56,12 +56,12 @@ impl CssRule for NoVBindPerformance {
             result.add_diagnostic(
                 LintDiagnostic::warn(
                     META.name,
-                    "v-bind() has runtime performance cost",
+                    "v-bind() installs runtime CSS variable updates",
                     start,
                     end,
                 )
                 .with_help(
-                    "v-bind() creates reactive CSS custom properties. Consider static CSS or computed classes for better performance",
+                    "Vue lowers CSS v-bind() to per-instance reactive CSS custom property updates. Prefer static CSS, computed classes for finite variants, or a template :style binding when a prop-driven value is unavoidable.",
                 ),
             );
 
@@ -114,6 +114,19 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint(".button { color: v-bind(color); }", 0);
         assert_eq!(result.warning_count, 1);
+        assert_eq!(
+            result.diagnostics[0].message.as_str(),
+            "v-bind() installs runtime CSS variable updates"
+        );
+        assert_eq!(
+            result.diagnostics[0]
+                .help
+                .as_ref()
+                .map(|help| help.as_str()),
+            Some(
+                "Vue lowers CSS v-bind() to per-instance reactive CSS custom property updates. Prefer static CSS, computed classes for finite variants, or a template :style binding when a prop-driven value is unavoidable."
+            )
+        );
     }
 
     #[test]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |          1136 |                   787 |               349 |             158 |     373 |            1009 |      658 |           561 |           700 |
-| Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           568 |
+| Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           569 |
 | Typechecker                |           925 |                   255 |               670 |             414 |     214 |             869 |      684 |           500 |           715 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |


### PR DESCRIPTION
## Summary
- keep the opinionated preset regression-covered so prop-driven `:style` bindings remain a clean path
- update `css/no-v-bind-performance` to name the per-instance reactive CSS variable update cost
- point the diagnostic help at static CSS, computed classes, or template `:style` for unavoidable prop-driven values

## Verification
- `cargo test -p vize_patina no_v_bind_performance -- --nocapture`
- `cargo test -p vize_patina prop_style_policy -- --nocapture`
- `cargo fmt --all --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check origin/main`

Closes #5999

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791623121&installation_model_id=422833&pr_number=6018&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6018&signature=41ac3212706754c0c6545408f4ab6ef9028cbce4500c57696470c43467f974f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Clarified the `css/no-v-bind-performance` warning to explain that `v-bind()` creates runtime CSS variable updates for each component instance.
  - Added more detailed guidance to help developers understand and address the performance impact.
  - Confirmed that prop-driven inline style bindings remain supported under the Opinionated linting preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->