### PR TITLE
fix(sfc): normalize mixed legacy deep markers

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope/legacy_deep.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope/legacy_deep.rs
@@ -50,6 +50,12 @@ fn strip_legacy_markers(selector: &str) -> String {
         output.push_str(selector[cursor..marker.start].trim_end());
         push_descendant_space(&mut output);
         cursor = skip_ws(selector, marker.end);
+        if let Some(target) = parenthesized_deep_target(selector, cursor) {
+            output.push_str(
+                strip_legacy_markers(&selector[target.inner_start..target.inner_end]).trim(),
+            );
+            cursor = target.end;
+        }
         changed = true;
     }
 
@@ -59,6 +65,26 @@ fn strip_legacy_markers(selector: &str) -> String {
 
     output.push_str(&selector[cursor..]);
     output
+}
+
+struct ParenthesizedTarget {
+    inner_start: usize,
+    inner_end: usize,
+    end: usize,
+}
+
+fn parenthesized_deep_target(selector: &str, cursor: usize) -> Option<ParenthesizedTarget> {
+    if !selector[cursor..].starts_with('(') {
+        return None;
+    }
+
+    let inner_start = cursor + 1;
+    let inner_end = find_matching_paren(selector, cursor)?;
+    Some(ParenthesizedTarget {
+        inner_start,
+        inner_end,
+        end: inner_end + 1,
+    })
 }
 
 fn push_descendant_space(output: &mut String) {

--- a/crates/vize_atelier_sfc/tests/vite_css_scope.rs
+++ b/crates/vize_atelier_sfc/tests/vite_css_scope.rs
@@ -15,12 +15,12 @@ fn vite_pipeline_scopes_parent_before_trailing_universal_selectors() {
 #[test]
 fn vite_pipeline_rewrites_legacy_deep_combinators() {
     let output = scope_css_for_pipeline(
-        ".panel >>> .inner >>> .leaf { padding: 0; }.panel ::v-deep .other /deep/ .child { margin: 0; }[data-label=\">>>\"] .plain { color: red; }.panel[data-token=\"::v-deep\"] { color: blue; }.literal\\>\\>\\> .plain { color: green; }",
+        ".panel >>> .inner ::v-deep(.leaf) { padding: 0; }.panel ::v-deep(.other) /deep/ ::v-deep(.child) { margin: 0; }[data-label=\">>>\"] .plain { color: red; }.panel[data-token=\"::v-deep\"] { color: blue; }.panel/* >>> */ .after-comment { color: purple; }.literal\\>\\>\\> .plain { color: green; }",
         "data-v-x",
     );
 
     assert_eq!(
         output.as_str(),
-        ".panel[data-v-x] .inner .leaf{padding: 0;}.panel[data-v-x] .other .child{margin: 0;}[data-label=\">>>\"] .plain[data-v-x]{color: red;}.panel[data-token=\"::v-deep\"][data-v-x]{color: blue;}.literal\\>\\>\\> .plain[data-v-x]{color: green;}"
+        ".panel[data-v-x] .inner .leaf{padding: 0;}.panel[data-v-x] .other .child{margin: 0;}[data-label=\">>>\"] .plain[data-v-x]{color: red;}.panel[data-token=\"::v-deep\"][data-v-x]{color: blue;}.panel/* >>> */ .after-comment[data-v-x]{color: purple;}.literal\\>\\>\\> .plain[data-v-x]{color: green;}"
     );
 }


### PR DESCRIPTION
Refs #6007.\n\n## Summary\n- unwrap parenthesized legacy deep targets that appear after the first legacy deep marker\n- keep marker-like text inside attribute values, comments, and escaped selectors from being treated as deep syntax\n\n## Tests\n- cargo test -p vize_atelier_sfc vite_pipeline_rewrites_legacy_deep_combinators -- --nocapture\n- cargo fmt --all --check\n- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5\n- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791623606&installation_model_id=422833&pr_number=6019&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6019&signature=c385dc781161f6c7822a127fa581c49a374b34cbca7007bddf3e00caa60d8abf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->