### PR TITLE
fix(vite-plugin): resolve package imports from virtual SFCs

### DIFF
--- a/npm/builder/vite/src/plugin/package-imports.test.ts
+++ b/npm/builder/vite/src/plugin/package-imports.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { VizePluginState } from "./state.ts";
+import { resolveIdHook } from "./resolve.ts";
+import { toPluginVisibleVirtualId, toVirtualId } from "../virtual.ts";
+
+const testRoot = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "vize-package-imports-"));
+
+function writeFixtureFile(filePath: string, content = ""): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function createState(root: string): VizePluginState {
+  return {
+    cache: new Map(),
+    ssrCache: new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: false,
+    root,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: {} as never,
+    filter: () => true,
+    scanPatterns: ["**/*.vue"],
+    precompileBatchSize: 128,
+    ignorePatterns: [],
+    mergedOptions: {},
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: {
+      log() {},
+      info() {},
+      warn() {},
+      error() {},
+    } as never,
+  };
+}
+
+function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): string {
+  assert.notEqual(resolved, null);
+  assert.notEqual(resolved, undefined);
+  return typeof resolved === "string" ? resolved : resolved.id;
+}
+
+{
+  const root = fs.mkdtempSync(path.join(testRoot, "extensionless-"));
+  const source = path.join(root, "app", "pages", "index.vue");
+  const resolvedType = path.join(root, "types", "index.ts");
+  writeFixtureFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      private: true,
+      imports: {
+        "#types/*": "./types/*",
+      },
+    }),
+  );
+  writeFixtureFile(
+    source,
+    "<script setup lang=\"ts\">import type { User } from '#types/index'</script>",
+  );
+  writeFixtureFile(resolvedType, "export interface User { name: string }\n");
+
+  let resolverImporter: string | undefined;
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (_id: string, importer?: string) => {
+        resolverImporter = importer;
+        throw new Error('Missing "#types/index" specifier in "nuxt" package');
+      },
+    },
+    createState(root),
+    "#types/index",
+    toPluginVisibleVirtualId(source),
+    undefined,
+  );
+
+  assert.equal(resolverImporter, source);
+  assert.equal(
+    expectResolvedId(resolved),
+    resolvedType,
+    "Package imports from plugin-visible Vize SFC modules should resolve against the source package",
+  );
+}
+
+{
+  const root = fs.mkdtempSync(path.join(testRoot, "virtual-"));
+  const source = path.join(root, "app", "components", "Profile.vue");
+  const resolvedRuntime = path.join(root, "runtime", "profile.ts");
+  writeFixtureFile(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      private: true,
+      imports: {
+        "#runtime/*": {
+          import: "./runtime/*",
+        },
+      },
+    }),
+  );
+  writeFixtureFile(source, "<script setup>import profile from '#runtime/profile'</script>");
+  writeFixtureFile(resolvedRuntime, "export default {};\n");
+
+  const resolved = await resolveIdHook(
+    { resolve: async () => null },
+    createState(root),
+    "#runtime/profile",
+    toVirtualId(source),
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    resolvedRuntime,
+    "Package imports from Rollup-internal Vize SFC modules should use the original source package",
+  );
+}

--- a/npm/builder/vite/src/plugin/package-imports.ts
+++ b/npm/builder/vite/src/plugin/package-imports.ts
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+import {
+  createViteBareImportBases,
+  resolveViteRelativeImport,
+  splitViteIdQuery,
+} from "@vizejs/native";
+
+import type { VizePluginState } from "./state.ts";
+
+const PACKAGE_IMPORT_CONDITIONS = [
+  "browser",
+  "import",
+  "module",
+  "default",
+  "node",
+  "require",
+  "types",
+] as const;
+
+type PackageImportMap = Record<string, unknown>;
+
+export function resolvePackageJsonImportFromVizeImporter(
+  state: Pick<VizePluginState, "root">,
+  id: string,
+  importer: string,
+): string | null {
+  const { request, querySuffix } = splitViteIdQuery(id);
+  if (!request.startsWith("#")) {
+    return null;
+  }
+
+  const seen = new Set<string>();
+  for (const base of createViteBareImportBases(state.root, importer)) {
+    const packageRoot = findPackageScope(base);
+    if (!packageRoot || seen.has(packageRoot)) {
+      continue;
+    }
+    seen.add(packageRoot);
+
+    const direct = tryRequireResolve(path.join(packageRoot, "package.json"), request, querySuffix);
+    if (direct) {
+      return direct;
+    }
+
+    const imports = readPackageImports(packageRoot);
+    const target = imports ? resolvePackageImportTarget(imports, request) : null;
+    const resolved = target
+      ? resolvePackageImportTargetPath(packageRoot, target, importer, querySuffix)
+      : null;
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return null;
+}
+
+function findPackageScope(base: string): string | null {
+  let current = fs.existsSync(base) && fs.statSync(base).isDirectory() ? base : path.dirname(base);
+  while (current !== path.dirname(current)) {
+    if (fs.existsSync(path.join(current, "package.json"))) {
+      return current;
+    }
+    current = path.dirname(current);
+  }
+  return null;
+}
+
+function tryRequireResolve(base: string, request: string, querySuffix: string): string | null {
+  try {
+    return `${createRequire(base).resolve(request)}${querySuffix}`;
+  } catch {
+    return null;
+  }
+}
+
+function readPackageImports(packageRoot: string): PackageImportMap | null {
+  try {
+    const json = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8")) as {
+      imports?: unknown;
+    };
+    return isPlainObject(json.imports) ? json.imports : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolvePackageImportTarget(imports: PackageImportMap, request: string): string | null {
+  const exact = resolveConditionalTarget(imports[request]);
+  if (exact) {
+    return exact;
+  }
+
+  let best: { keyLength: number; target: string } | null = null;
+  for (const [key, value] of Object.entries(imports)) {
+    const starIndex = key.indexOf("*");
+    if (starIndex === -1) {
+      continue;
+    }
+    const prefix = key.slice(0, starIndex);
+    const suffix = key.slice(starIndex + 1);
+    if (!request.startsWith(prefix) || !request.endsWith(suffix)) {
+      continue;
+    }
+
+    const target = resolveConditionalTarget(value);
+    if (!target || (best && key.length <= best.keyLength)) {
+      continue;
+    }
+    const matched = request.slice(prefix.length, request.length - suffix.length);
+    best = { keyLength: key.length, target: target.replaceAll("*", matched) };
+  }
+
+  return best?.target ?? null;
+}
+
+function resolveConditionalTarget(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const target = resolveConditionalTarget(item);
+      if (target) {
+        return target;
+      }
+    }
+    return null;
+  }
+  if (!isPlainObject(value)) {
+    return null;
+  }
+  for (const condition of PACKAGE_IMPORT_CONDITIONS) {
+    const target = resolveConditionalTarget(value[condition]);
+    if (target) {
+      return target;
+    }
+  }
+  return null;
+}
+
+function resolvePackageImportTargetPath(
+  packageRoot: string,
+  target: string,
+  importer: string,
+  querySuffix: string,
+): string | null {
+  const { request } = splitViteIdQuery(target);
+  if (request.startsWith("./")) {
+    const resolved = resolveViteRelativeImport(request, path.join(packageRoot, "package.json"));
+    return resolved && isInsidePackage(packageRoot, resolved) ? `${resolved}${querySuffix}` : null;
+  }
+  if (request.startsWith("../")) {
+    return null;
+  }
+  if (path.isAbsolute(request)) {
+    return fs.existsSync(request) ? `${request}${querySuffix}` : null;
+  }
+  return tryRequireResolve(importer, request, querySuffix);
+}
+
+function isPlainObject(value: unknown): value is PackageImportMap {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isInsidePackage(packageRoot: string, resolved: string): boolean {
+  const relative = path.relative(packageRoot, splitViteIdQuery(resolved).request);
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}

--- a/npm/builder/vite/src/plugin/resolve.ts
+++ b/npm/builder/vite/src/plugin/resolve.ts
@@ -16,6 +16,7 @@ import {
 
 import type { VizePluginState } from "./state.ts";
 import { isInsidePath, isProjectSourceImporter, normalizeImporterFilePath } from "./importer.ts";
+import { resolvePackageJsonImportFromVizeImporter } from "./package-imports.ts";
 import { cleanVueSfcImporter, resolveRelativeVueSfcImport } from "./resolve-relative-vue.ts";
 import {
   LEGACY_VIZE_PREFIX,
@@ -664,9 +665,7 @@ function nativeCssAliasRules(
 }
 
 function isPotentialVizeResolveId(id: string): boolean {
-  // `resolveId` is called for every dependency in a Vite graph. Most bare
-  // package imports cannot be Vize-owned, so this cheap string gate keeps regular
-  // dependencies off the heavier classifier/alias/Node-resolution path.
+  // Keep regular dependencies off the heavier classifier/alias/Node-resolution path.
   return (
     id.startsWith("\0") ||
     id.startsWith("vize:") ||
@@ -688,8 +687,6 @@ function classifyImporterRequest(
 }
 
 export function isPotentialVizeImporter(importer: string | undefined): boolean {
-  // Imports from Vize virtual modules still need custom resolution even when the
-  // requested id itself is a regular-looking relative or bare specifier.
   if (importer === undefined) {
     return false;
   }
@@ -697,12 +694,8 @@ export function isPotentialVizeImporter(importer: string | undefined): boolean {
     return true;
   }
 
-  // This gate keeps ordinary dependency edges off the classifier, so it must not
-  // call the classifier itself (#3427). `isVueSfcPath` is
-  // `normalizedVuePath.endsWith(".vue")`, and `normalizedVuePath` only ever strips
-  // a trailing `.ts`/`.tsx` from the pre-`?` path, so it can only end in `.vue`
-  // when the importer contains `.vue`: a strictly weaker test, so every importer
-  // the classifier would have accepted still reaches it.
+  // Avoid classifying ordinary dependency edges while still catching every
+  // classifier-accepted Vue importer (#3427).
   return importer.includes(".vue");
 }
 
@@ -945,13 +938,12 @@ export async function resolveIdHook(
       return relativeVueResolved;
     }
 
-    // Subpath imports (e.g., #imports/entry from Nuxt)
     if (id.startsWith("#")) {
       try {
-        return await resolveWithVite(ctx, state, id, cleanImporter, { skipSelf: true });
-      } catch {
-        return null;
-      }
+        const resolved = await resolveWithVite(ctx, state, id, cleanImporter, { skipSelf: true });
+        if (resolved) return resolved;
+      } catch {}
+      return resolvePackageJsonImportFromVizeImporter(state, id, cleanImporter);
     }
 
     // For non-vue files, resolve relative to the real importer

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -29,6 +29,7 @@ import "./plugin/load-storybook.test.ts";
 import "./plugin/load.test.ts";
 import "./plugin/load-dependency-sfc.test.ts";
 import "./plugin/native.test.ts";
+import "./plugin/package-imports.test.ts";
 import "./plugin/quasar.test.ts";
 import "./plugin/resolve-peer-runtime.test.ts";
 import "./plugin/resolve-vue-runtime.test.ts";


### PR DESCRIPTION
## Summary
- Resolve project package.json `#...` imports from the original SFC package when Vize virtual modules import them.
- Preserve Nuxt/Vite resolver results first, then fall back to package imports with extensionless TypeScript targets.
- Add regression coverage for plugin-visible and Rollup-internal Vize SFC module ids.

Fixes #6001

## Validation
- `NAPI_RS_NATIVE_LIBRARY_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/vize--p0-6001-nuxt-package-imports/npm/native/.artifacts/native/vize-vitrine.darwin-arm64.node ./node_modules/.bin/node npm/builder/vite/src/plugin/package-imports.test.ts`
- `./node_modules/.bin/oxfmt --check npm/builder/vite/src/plugin/package-imports.ts npm/builder/vite/src/plugin/package-imports.test.ts npm/builder/vite/src/plugin/resolve.ts npm/builder/vite/src/test.ts`
- `./node_modules/.bin/oxlint npm/builder/vite/src/plugin/package-imports.ts npm/builder/vite/src/plugin/package-imports.test.ts npm/builder/vite/src/plugin/resolve.ts npm/builder/vite/src/test.ts`
- `cargo fmt --all --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check origin/main`

## Local note
- `node npm/builder/vite/src/test.ts` stops in this worktree because the installed Rolldown binding exposes an undefined `TsconfigCache`; Actions will cover the full package matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791625872&installation_model_id=422833&pr_number=6021&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6021&signature=64bf5b91fb4480f3e71b5f5cade5d83a23aed4414f006ba24a2caabd119d2fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving Node.js package `#`-imports from Vize virtual modules and Vue files.
  * Supports exact and wildcard import mappings, conditional targets, query suffixes, and package-scoped paths.

* **Bug Fixes**
  * Improved fallback resolution when standard Vite resolution cannot resolve a package subpath import.

* **Tests**
  * Added coverage for package import resolution across source files and virtual module identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->