### PR TITLE
fix(vite-plugin): bound workspace precompile scans

### DIFF
--- a/npm/builder/vite/src/plugin/precompile-run.ts
+++ b/npm/builder/vite/src/plugin/precompile-run.ts
@@ -87,6 +87,7 @@ export async function compileAll(state: VizePluginState): Promise<void> {
     cwd: state.root,
     ignore: state.ignorePatterns,
     absolute: true,
+    followSymbolicLinks: false,
   });
   const sfcFiles = files.filter(isPrecompileSfcPath);
 

--- a/npm/builder/vite/src/plugin/precompile.test.ts
+++ b/npm/builder/vite/src/plugin/precompile.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { DEFAULT_PRECOMPILE_BATCH_SIZE, type VizePluginState } from "./state.ts";
+import {
+  DEFAULT_PRECOMPILE_BATCH_SIZE,
+  DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
+  type VizePluginState,
+} from "./state.ts";
 import { compileAll } from "./precompile-run.ts";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,5 +83,63 @@ assert.equal(
   false,
   "TSX scan matches should not get SFC precompile metadata",
 );
+
+const workspaceRootForScan = fs.mkdtempSync(path.join(testRoot, "workspace-scan-"));
+const workspaceSourceRoot = path.join(workspaceRootForScan, "src");
+fs.mkdirSync(workspaceSourceRoot, { recursive: true });
+const workspaceApp = path.join(workspaceSourceRoot, "App.vue");
+fs.writeFileSync(workspaceApp, `<template><div>workspace</div></template>`);
+
+const nestedNodeModulesSfc = path.join(
+  workspaceRootForScan,
+  "packages",
+  "app",
+  "node_modules",
+  "linked",
+  "Nested.vue",
+);
+fs.mkdirSync(path.dirname(nestedNodeModulesSfc), { recursive: true });
+fs.writeFileSync(nestedNodeModulesSfc, `<template><div>nested dependency</div></template>`);
+
+const externalPackage = fs.mkdtempSync(path.join(testRoot, "external-package-"));
+const externalSfc = path.join(externalPackage, "Linked.vue");
+fs.writeFileSync(externalSfc, `<template><div>external dependency</div></template>`);
+const symlinkPath = path.join(workspaceRootForScan, "packages", "app", "linked-package");
+let symlinkCreated = false;
+try {
+  fs.symlinkSync(externalPackage, symlinkPath, "dir");
+  symlinkCreated = true;
+} catch {
+  // Some Windows developer shells cannot create directory symlinks. The nested
+  // node_modules assertion still covers the default workspace guard.
+}
+
+const workspaceState: VizePluginState = {
+  ...state,
+  cache: new Map(),
+  ssrCache: new Map(),
+  collectedCss: new Map(),
+  precompileMetadata: new Map(),
+  pendingHmrUpdateTypes: new Map(),
+  root: workspaceRootForScan,
+  scanPatterns: ["**/*.vue"],
+  ignorePatterns: [...DEFAULT_PRECOMPILE_IGNORE_PATTERNS],
+};
+
+await compileAll(workspaceState);
+
+assert.ok(workspaceState.cache.has(workspaceApp), "First-party SFCs should still pre-compile");
+assert.equal(
+  workspaceState.cache.has(nestedNodeModulesSfc),
+  false,
+  "Pre-compilation should ignore nested node_modules in pnpm workspaces",
+);
+if (symlinkCreated) {
+  assert.equal(
+    [...workspaceState.cache.keys()].some((filePath) => filePath.includes("Linked.vue")),
+    false,
+    "Pre-compilation should not follow directory symlinks during workspace scans",
+  );
+}
 
 console.log("✅ vite-plugin-vize precompile tests passed!");

--- a/npm/builder/vite/src/plugin/precompile.ts
+++ b/npm/builder/vite/src/plugin/precompile.ts
@@ -11,12 +11,19 @@ export const DEFAULT_PRECOMPILE_BATCH_MAX_BYTES = 32 * 1024 * 1024;
 
 export const DEFAULT_PRECOMPILE_IGNORE_PATTERNS = [
   "node_modules/**",
+  "**/node_modules/**",
   "dist/**",
+  "**/dist/**",
   ".git/**",
+  "**/.git/**",
   ".nuxt/**",
+  "**/.nuxt/**",
   ".output/**",
+  "**/.output/**",
   ".nitro/**",
+  "**/.nitro/**",
   "coverage/**",
+  "**/coverage/**",
 ];
 
 export interface PrecompileFileMetadata {

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -211,8 +211,9 @@ export interface VizeOptions extends ExperimentalPluginOptions {
   precompileBatchSize?: number;
 
   /**
-   * Glob patterns to ignore during pre-compilation
-   * @default ['node_modules/**', 'dist/**', '.git/**', '.nuxt/**', '.output/**', '.nitro/**', 'coverage/**']
+   * Glob patterns to ignore during pre-compilation. Defaults exclude common
+   * dependency and build-output directories at the project root and at any
+   * workspace package depth.
    */
   ignorePatterns?: string[];
 

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -58,7 +58,7 @@
     "check:fix": "vp check --fix src tests vite.config.ts",
     "fmt": "vp fmt --write src tests vite.config.ts",
     "generate:rule-types": "vp run --workspace-root generate:rule-types",
-    "test": "vp pack && vp test run tests/corsa-runtime.test.ts tests/setup.test.ts tests/setup-oxlint-config.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-tsconfig.test.ts tests/init-prompt.test.ts"
+    "test": "vp pack && vp test run tests/config.test.ts tests/corsa-runtime.test.ts tests/setup.test.ts tests/setup-oxlint-config.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-tsconfig.test.ts tests/init-prompt.test.ts"
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",

--- a/npm/cli/src/config.ts
+++ b/npm/cli/src/config.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { transform } from "oxc-transform";
+import * as oxcTransform from "oxc-transform";
 import type {
   ResolvedVizeConfig,
   LoadConfigOptions,
@@ -164,17 +164,18 @@ async function loadTypeScriptConfig(
   env?: ConfigEnv,
 ): Promise<ResolvedVizeConfig> {
   const source = fs.readFileSync(filePath, "utf-8");
-  const result = await transform(filePath, source, {
+  const result = await oxcTransform.transform(filePath, source, {
     typescript: {
       onlyRemoveTypeImports: true,
     },
   });
+  const code = rewriteSelfConfigImports(result.code);
 
   const tempFile = path.join(
     path.dirname(filePath),
     `.vize-config-${process.pid}-${Date.now()}-${randomUUID()}.mjs`,
   );
-  fs.writeFileSync(tempFile, result.code, { flag: "wx", mode: 0o600 });
+  fs.writeFileSync(tempFile, code, { flag: "wx", mode: 0o600 });
 
   try {
     const module = await importFresh(tempFile);
@@ -195,6 +196,28 @@ async function importFresh(filePath: string): Promise<Record<string, unknown>> {
   const fileUrl = pathToFileURL(filePath);
   fileUrl.searchParams.set("t", String(fs.statSync(filePath).mtimeMs));
   return import(fileUrl.href);
+}
+
+function rewriteSelfConfigImports(code: string): string {
+  return code
+    .replace(/\bfrom\s+(["'])(vize(?:\/config)?)\1/gu, (_match, quote, specifier) => {
+      return `from ${quote}${resolveSelfConfigImportUrl(specifier)}${quote}`;
+    })
+    .replace(/\bimport\s+(["'])(vize(?:\/config)?)\1/gu, (_match, quote, specifier) => {
+      return `import ${quote}${resolveSelfConfigImportUrl(specifier)}${quote}`;
+    })
+    .replace(/\bimport\s*\(\s*(["'])(vize(?:\/config)?)\1\s*\)/gu, (_match, quote, specifier) => {
+      return `import(${quote}${resolveSelfConfigImportUrl(specifier)}${quote})`;
+    });
+}
+
+function resolveSelfConfigImportUrl(specifier: string): string {
+  const distTarget =
+    specifier === "vize"
+      ? path.join(PACKAGE_ROOT, "dist", "index.mjs")
+      : path.join(PACKAGE_ROOT, "dist", "config.mjs");
+  const sourceTarget = path.join(PACKAGE_ROOT, "src", "config.ts");
+  return pathToFileURL(fs.existsSync(distTarget) ? distTarget : sourceTarget).href;
 }
 
 function parseJsonConfig(content: string, filePath: string): ResolvedVizeConfig {

--- a/npm/cli/tests/config.test.ts
+++ b/npm/cli/tests/config.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+
+import { loadConfig } from "../src/config.ts";
+
+test("loads TypeScript config self-imports without a root vize dependency", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-config-self-import-"));
+  fs.writeFileSync(
+    path.join(root, "vize.config.ts"),
+    `import { defineConfig } from "vize";
+
+export default defineConfig({
+  vite: {
+    scanPatterns: ["src/**/*.vue"],
+  },
+});
+`,
+  );
+
+  const loaded = await loadConfig(root);
+
+  assert.deepEqual(
+    loaded?.vite.scanPatterns,
+    ["src/**/*.vue"],
+    "TypeScript config self-imports should not require a root vize dependency",
+  );
+});


### PR DESCRIPTION
## Summary
- stop Vite precompilation from following directory symlinks during workspace scans
- ignore common dependency/build-output directories at nested workspace package depth by default
- keep vize.config.ts self-imports working when `vize` is only available transitively through the Vite plugin

Fixes #6005

## Tests
- NAPI_RS_NATIVE_LIBRARY_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/vize--p0-6005-scan-boundary/npm/native/.artifacts/native/vize-vitrine.darwin-arm64.node ./node_modules/.bin/node npm/builder/vite/src/plugin/precompile.test.ts
- VIZE_ALLOW_NATIVE_VERSION_MISMATCH=1 node /Users/ubugeeei/.cache/node/corepack/v1/pnpm/12.1.0/bin/pnpm.mjs --dir npm/cli exec vp test run tests/config.test.ts
- ./node_modules/.bin/oxfmt --check npm/cli/package.json npm/cli/tests/config.test.ts npm/builder/vite/src/plugin/precompile-run.ts npm/builder/vite/src/plugin/precompile.test.ts npm/builder/vite/src/plugin/precompile.ts npm/builder/vite/src/types.ts npm/cli/src/config.ts
- ./node_modules/.bin/oxlint npm/cli/package.json npm/cli/tests/config.test.ts npm/builder/vite/src/plugin/precompile-run.ts npm/builder/vite/src/plugin/precompile.test.ts npm/builder/vite/src/plugin/precompile.ts npm/builder/vite/src/types.ts npm/cli/src/config.ts
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791627006&installation_model_id=422833&pr_number=6022&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6022&signature=63c5dd124a19f5cae9b4723421f1ff3b3b1eef9b463e1551d24b447fa1ebaca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pre-compilation now excludes files accessed through symbolic links, preventing external packages from being scanned unintentionally.
  - Common dependency and build-output directories are now ignored at all workspace nesting levels.
  - TypeScript configuration files can self-import configuration helpers without requiring a separately installed root-level package.

- **Documentation**
  - Updated `ignorePatterns` guidance to clarify default exclusions across project and workspace package directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->