### PR TITLE
fix(canon): keep declaration mirrors single-identity

### DIFF
--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -21,14 +21,12 @@ use collect::{ModuleSpecifierCollector, collect_specifier_occurrences};
 #[path = "import_rewriter_virtual.rs"]
 mod virtual_rewrite;
 pub(super) use virtual_rewrite::rewrite_relative_vue_specifier;
-use virtual_rewrite::{
-    absolute_import_needs_virtual_rewrite, is_rewritable_project_specifier,
-    is_rewritable_vue_specifier,
-};
 
 #[path = "import_rewriter_dts.rs"]
 mod dts_rewrite;
-use dts_rewrite::rewrite_relative_dts_specifier;
+
+#[path = "import_rewriter_project_mirror.rs"]
+mod project_mirror;
 
 #[path = "import_rewriter_source_map.rs"]
 mod source_map;
@@ -78,55 +76,6 @@ impl ImportRewriter {
                 true,
             )
             .or_else(|| source_dir.and_then(|dir| rewrite_relative_vue_specifier(path, dir)))
-        })
-    }
-
-    /// Rewrite a script's module specifiers for the canon virtual project.
-    /// `source_dir` (when known) enables the generated-`.d.ts` redirect (#2227).
-    pub fn rewrite_for_virtual_project(
-        &self,
-        source: &str,
-        source_type: SourceType,
-        roots: (&std::path::Path, &std::path::Path),
-        source_dir: Option<&std::path::Path>,
-    ) -> RewriteResult {
-        self.rewrite_for_virtual_project_with_policy(source, source_type, roots, source_dir, false)
-    }
-
-    pub(crate) fn rewrite_for_package_shadow(
-        &self,
-        source: &str,
-        source_type: SourceType,
-        roots: (&std::path::Path, &std::path::Path),
-        source_dir: Option<&std::path::Path>,
-    ) -> RewriteResult {
-        self.rewrite_for_virtual_project_with_policy(source, source_type, roots, source_dir, true)
-    }
-
-    fn rewrite_for_virtual_project_with_policy(
-        &self,
-        source: &str,
-        source_type: SourceType,
-        roots: (&std::path::Path, &std::path::Path),
-        source_dir: Option<&std::path::Path>,
-        preserve_relative_declarations: bool,
-    ) -> RewriteResult {
-        let project_root = roots.0.to_string_lossy();
-        let dts_candidate = source_dir.is_some() && source_may_contain_relative_specifier(source);
-        if !source.contains(".vue") && !source.contains(project_root.as_ref()) && !dts_candidate {
-            return RewriteResult {
-                code: source.to_compact_string(),
-                source_map: ImportSourceMap::empty(),
-            };
-        }
-
-        self.rewrite_with(source, source_type, |path, _| {
-            self.rewrite_virtual_project_specifier(
-                path,
-                roots,
-                source_dir,
-                preserve_relative_declarations,
-            )
         })
     }
 
@@ -264,51 +213,6 @@ impl ImportRewriter {
         source_type: SourceType,
     ) -> Vec<(String, crate::PackageResolutionMode)> {
         collect_specifier_occurrences(source, source_type)
-    }
-
-    fn rewrite_virtual_project_specifier(
-        &self,
-        path: &str,
-        roots: (&std::path::Path, &std::path::Path),
-        source_dir: Option<&std::path::Path>,
-        preserve_relative_declarations: bool,
-    ) -> Option<String> {
-        if let Some(rewritten) =
-            authored_vue_ts::rewrite_authored_or_missing_vue_import(path, source_dir, true, false)
-        {
-            return Some(rewritten);
-        }
-        if let Some(source_dir) = source_dir
-            && let Some(rewritten) = (!preserve_relative_declarations)
-                .then(|| rewrite_relative_dts_specifier(path, source_dir, roots.0))
-                .flatten()
-                .or_else(|| rewrite_relative_vue_specifier(path, source_dir))
-        {
-            return Some(rewritten);
-        }
-        let candidate = std::path::Path::new(path);
-        let canonical_candidate = vize_carton::path::canonicalize_non_verbatim(candidate);
-        let canonical_project_root = vize_carton::path::canonicalize_non_verbatim(roots.0);
-        if candidate.is_absolute()
-            && let Ok(relative) = canonical_candidate
-                .strip_prefix(canonical_project_root.as_path())
-                .or_else(|_| candidate.strip_prefix(roots.0))
-            && is_rewritable_project_specifier(relative)
-        {
-            if !path.ends_with(".vue") && !absolute_import_needs_virtual_rewrite(candidate) {
-                return None;
-            }
-            let mut rewritten = cstr!("{}", roots.1.join(relative).display());
-            if path.ends_with(".vue") {
-                rewritten.push_str(".ts");
-            }
-            return Some(rewritten);
-        }
-        if is_rewritable_vue_specifier(path) {
-            Some(cstr!("{path}.ts"))
-        } else {
-            None
-        }
     }
 
     fn rewrite_declaration_specifier(&self, path: &str) -> Option<String> {

--- a/crates/vize_canon/src/batch/import_rewriter_project_mirror.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_project_mirror.rs
@@ -1,0 +1,229 @@
+//! Virtual-project mirror rewrites for in-project absolute imports.
+
+use std::path::{Path, PathBuf};
+
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String, ToCompactString, cstr};
+
+use super::dts_rewrite::rewrite_relative_dts_specifier;
+use super::virtual_rewrite::{
+    absolute_import_needs_virtual_rewrite, is_rewritable_project_specifier,
+    is_rewritable_vue_specifier, resolve_source_path,
+};
+use super::{
+    ImportRewriter, ImportSourceMap, RewriteResult, authored_vue_ts,
+    rewrite_relative_vue_specifier, source_may_contain_relative_specifier,
+};
+
+impl ImportRewriter {
+    pub(in crate::batch) fn rewrite_generated_for_virtual_project(
+        &self,
+        source: &str,
+        source_type: SourceType,
+        roots: (&Path, &Path),
+        source_dir: Option<&Path>,
+        mirrorable_project_files: Option<&FxHashSet<PathBuf>>,
+    ) -> RewriteResult {
+        let project_root = roots.0.to_string_lossy();
+        let relative_candidate =
+            source_dir.is_some() && source_may_contain_relative_specifier(source);
+        if !source.contains(".vue")
+            && !source.contains(project_root.as_ref())
+            && !relative_candidate
+        {
+            return RewriteResult {
+                code: source.to_compact_string(),
+                source_map: ImportSourceMap::empty(),
+            };
+        }
+
+        self.rewrite_with(source, source_type, |path, _| {
+            self.rewrite_module_specifier_with_missing_vue_policy(path, source_dir, true, true)
+                .or_else(|| source_dir.and_then(|dir| rewrite_relative_vue_specifier(path, dir)))
+                .or_else(|| {
+                    self.rewrite_known_virtual_project_specifier(
+                        path,
+                        roots,
+                        mirrorable_project_files,
+                    )
+                })
+        })
+    }
+
+    /// Rewrite a script's module specifiers for the canon virtual project.
+    /// `source_dir` (when known) enables the generated-`.d.ts` redirect (#2227).
+    pub fn rewrite_for_virtual_project(
+        &self,
+        source: &str,
+        source_type: SourceType,
+        roots: (&Path, &Path),
+        source_dir: Option<&Path>,
+    ) -> RewriteResult {
+        self.rewrite_for_virtual_project_with_policy(
+            source,
+            source_type,
+            roots,
+            source_dir,
+            false,
+            None,
+        )
+    }
+
+    pub(crate) fn rewrite_for_package_shadow(
+        &self,
+        source: &str,
+        source_type: SourceType,
+        roots: (&Path, &Path),
+        source_dir: Option<&Path>,
+    ) -> RewriteResult {
+        self.rewrite_for_virtual_project_with_policy(
+            source,
+            source_type,
+            roots,
+            source_dir,
+            true,
+            None,
+        )
+    }
+
+    pub(in crate::batch) fn rewrite_for_virtual_project_with_mirrorable_files(
+        &self,
+        source: &str,
+        source_type: SourceType,
+        roots: (&Path, &Path),
+        source_dir: Option<&Path>,
+        mirrorable_project_files: Option<&FxHashSet<PathBuf>>,
+    ) -> RewriteResult {
+        self.rewrite_for_virtual_project_with_policy(
+            source,
+            source_type,
+            roots,
+            source_dir,
+            false,
+            mirrorable_project_files,
+        )
+    }
+
+    fn rewrite_for_virtual_project_with_policy(
+        &self,
+        source: &str,
+        source_type: SourceType,
+        roots: (&Path, &Path),
+        source_dir: Option<&Path>,
+        preserve_relative_declarations: bool,
+        mirrorable_project_files: Option<&FxHashSet<PathBuf>>,
+    ) -> RewriteResult {
+        let project_root = roots.0.to_string_lossy();
+        let dts_candidate = source_dir.is_some() && source_may_contain_relative_specifier(source);
+        if !source.contains(".vue") && !source.contains(project_root.as_ref()) && !dts_candidate {
+            return RewriteResult {
+                code: source.to_compact_string(),
+                source_map: ImportSourceMap::empty(),
+            };
+        }
+
+        self.rewrite_with(source, source_type, |path, _| {
+            self.rewrite_virtual_project_specifier(
+                path,
+                roots,
+                source_dir,
+                preserve_relative_declarations,
+                mirrorable_project_files,
+            )
+        })
+    }
+
+    fn rewrite_virtual_project_specifier(
+        &self,
+        path: &str,
+        roots: (&Path, &Path),
+        source_dir: Option<&Path>,
+        preserve_relative_declarations: bool,
+        mirrorable_project_files: Option<&FxHashSet<PathBuf>>,
+    ) -> Option<String> {
+        if let Some(rewritten) =
+            authored_vue_ts::rewrite_authored_or_missing_vue_import(path, source_dir, true, false)
+        {
+            return Some(rewritten);
+        }
+        if let Some(source_dir) = source_dir
+            && let Some(rewritten) = (!preserve_relative_declarations)
+                .then(|| rewrite_relative_dts_specifier(path, source_dir, roots.0))
+                .flatten()
+                .or_else(|| rewrite_relative_vue_specifier(path, source_dir))
+        {
+            return Some(rewritten);
+        }
+        let candidate = Path::new(path);
+        let canonical_candidate = vize_carton::path::canonicalize_non_verbatim(candidate);
+        let canonical_project_root = vize_carton::path::canonicalize_non_verbatim(roots.0);
+        if candidate.is_absolute()
+            && let Ok(relative) = canonical_candidate
+                .strip_prefix(canonical_project_root.as_path())
+                .or_else(|_| candidate.strip_prefix(roots.0))
+            && is_rewritable_project_specifier(relative)
+        {
+            if let Some(rewritten) =
+                self.rewrite_known_virtual_project_specifier(path, roots, mirrorable_project_files)
+            {
+                return Some(rewritten);
+            }
+            if !path.ends_with(".vue") && !absolute_import_needs_virtual_rewrite(candidate) {
+                return None;
+            }
+            let mut rewritten = cstr!("{}", roots.1.join(relative).display());
+            if path.ends_with(".vue") {
+                rewritten.push_str(".ts");
+            }
+            return Some(rewritten);
+        }
+        if is_rewritable_vue_specifier(path) {
+            Some(cstr!("{path}.ts"))
+        } else {
+            None
+        }
+    }
+
+    fn rewrite_known_virtual_project_specifier(
+        &self,
+        path: &str,
+        roots: (&Path, &Path),
+        mirrorable_project_files: Option<&FxHashSet<PathBuf>>,
+    ) -> Option<String> {
+        let mirrorable_project_files = mirrorable_project_files?;
+        let candidate = Path::new(path);
+        if !candidate.is_absolute() {
+            return None;
+        }
+        let resolved = resolve_source_path(candidate)?;
+        let canonical_resolved = vize_carton::path::canonicalize_non_verbatim(&resolved);
+        if !mirrorable_project_files.contains(&canonical_resolved) {
+            return None;
+        }
+        let canonical_candidate = vize_carton::path::canonicalize_non_verbatim(candidate);
+        let canonical_project_root = vize_carton::path::canonicalize_non_verbatim(roots.0);
+        let rewrites_vue_source = resolved
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension == "vue");
+        let relative = if rewrites_vue_source && !path.ends_with(".vue") {
+            canonical_resolved
+                .strip_prefix(canonical_project_root.as_path())
+                .or_else(|_| resolved.strip_prefix(roots.0))
+                .ok()?
+        } else {
+            canonical_candidate
+                .strip_prefix(canonical_project_root.as_path())
+                .or_else(|_| candidate.strip_prefix(roots.0))
+                .ok()?
+        };
+        if !is_rewritable_project_specifier(relative) {
+            return None;
+        }
+        let mut rewritten = cstr!("{}", roots.1.join(relative).display());
+        if rewrites_vue_source {
+            rewritten.push_str(".ts");
+        }
+        Some(rewritten)
+    }
+}

--- a/crates/vize_canon/src/batch/import_rewriter_virtual.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual.rs
@@ -70,7 +70,7 @@ fn source_needs_virtual_rewrite(path: &Path) -> bool {
     false
 }
 
-fn resolve_source_path(path: &Path) -> Option<PathBuf> {
+pub(super) fn resolve_source_path(path: &Path) -> Option<PathBuf> {
     if path.is_file() {
         return Some(path.to_path_buf());
     }

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -16,8 +16,10 @@ mod external_slot_payloads;
 mod global_component_callbacks;
 mod imported_component_ref_expose;
 mod imported_runtime_props;
+mod large_declaration_identity;
 mod literal_dynamic_slot_names;
 mod native_prop_anchors;
+mod normalization;
 mod open_slot_index_signature;
 mod optional_boolean_props;
 mod options_api_bridge_anchors;
@@ -43,24 +45,7 @@ mod v_for_source_callbacks;
 mod vapor_anchors;
 mod vue27_render_h;
 
-fn normalize_component_check_props_tail(message: &str) -> std::string::String {
-    const START: &str = "__VizeComponentCheckProps<Props, ";
-    const STABLE_TYPE: &str = "__VizeComponentCheckProps<Props, __VizeFallthroughAttrs>";
-    let mut output = std::string::String::with_capacity(message.len());
-    let mut rest = message;
-    while let Some(start) = rest.find(START) {
-        output.push_str(&rest[..start]);
-        let from_type = &rest[start..];
-        let Some(end) = from_type.find("'.") else {
-            output.push_str(from_type);
-            return output;
-        };
-        output.push_str(STABLE_TYPE);
-        rest = &from_type[end..];
-    }
-    output.push_str(rest);
-    output
-}
+pub(super) use normalization::normalize_component_check_props_tail;
 
 #[test]
 fn issue_2645_infers_generic_sfc_props_in_tsx() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/large_declaration_identity.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/large_declaration_identity.rs
@@ -1,0 +1,113 @@
+//! Large first-party declaration modules must keep one module identity (#6000).
+
+use super::super::{BatchTypeChecker, relative_path, resolve_test_tsgo_binary, unique_case_dir};
+use crate::batch::TypeChecker;
+use vize_carton::{String, cstr};
+
+type ReportedDiagnostic = (String, Option<u32>, String);
+
+#[test]
+fn aliased_large_declaration_module_and_absolute_import_share_identity() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = unique_case_dir("issue-6000-large-declaration-identity");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::create_dir_all(project_root.join("types")).unwrap();
+    super::super::link_workspace_node_modules(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["*"]
+    },
+    "noEmit": true
+  },
+  "include": ["src/**/*", "types/**/*.d.ts"]
+}"#,
+    )
+    .unwrap();
+    // `unique symbol` makes the duplicate module identity observable in a compact
+    // fixture; generated schemas can hit the same path through deeper branded or
+    // enum-bearing graphs.
+    let mut schema = std::string::String::from(
+        "export declare const QuestionBrand: unique symbol\n\
+         export enum QuestionKind { Text = 'TEXT', Choice = 'CHOICE' }\n\
+         export type Question = { readonly [QuestionBrand]: true; kind: QuestionKind; title: string }\n\
+         export type Node0 = { question: Question }\n",
+    );
+    for index in 1..384 {
+        schema.push_str(&format!(
+            "export type Node{index} = {{ previous: Node{}; question: Question }}\n",
+            index - 1
+        ));
+    }
+    schema.push_str("export type GeneratedSchema = Node383\n");
+    std::fs::write(project_root.join("types/schema.d.ts"), schema).unwrap();
+    std::fs::write(
+        project_root.join("src/question.ts"),
+        r#"import type { Question } from '~/types/schema';
+
+export function expectQuestion(question: Question): Question {
+  return question;
+}
+"#,
+    )
+    .unwrap();
+    let schema_specifier = project_root
+        .join("types/schema")
+        .to_string_lossy()
+        .replace('\\', "/");
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        cstr!(
+            r#"<script setup lang="ts">
+import {{ expectQuestion }} from './question';
+import {{ QuestionBrand, QuestionKind, type Question }} from '{schema_specifier}';
+
+const question: Question = {{
+  [QuestionBrand]: true,
+  kind: QuestionKind.Text,
+  title: 'Hello',
+}};
+
+expectQuestion(question);
+</script>
+
+<template><div /></template>
+"#
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let mut checker = BatchTypeChecker::new(&project_root).expect("batch checker construction");
+    checker.scan_project().expect("project scan");
+    let result = checker.check_project().expect("project check");
+    let mut diagnostics: Vec<ReportedDiagnostic> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                relative_path(&project_root, &diagnostic.file),
+                diagnostic.code,
+                diagnostic.message,
+            )
+        })
+        .collect();
+    diagnostics.sort();
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    assert!(
+        diagnostics.is_empty(),
+        "a single generated declaration module must not be duplicated into unrelated identities: {diagnostics:#?}"
+    );
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/normalization.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/normalization.rs
@@ -1,0 +1,18 @@
+pub(crate) fn normalize_component_check_props_tail(message: &str) -> std::string::String {
+    const START: &str = "__VizeComponentCheckProps<Props, ";
+    const STABLE_TYPE: &str = "__VizeComponentCheckProps<Props, __VizeFallthroughAttrs>";
+    let mut output = std::string::String::with_capacity(message.len());
+    let mut rest = message;
+    while let Some(start) = rest.find(START) {
+        output.push_str(&rest[..start]);
+        let from_type = &rest[start..];
+        let Some(end) = from_type.find("'.") else {
+            output.push_str(from_type);
+            return output;
+        };
+        output.push_str(STABLE_TYPE);
+        rest = &from_type[end..];
+    }
+    output.push_str(rest);
+    output
+}

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -4,7 +4,6 @@
 use std::path::{Path, PathBuf};
 
 use oxc_span::SourceType;
-use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::{String as CompactString, ToCompactString, cstr, profile};
 
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
@@ -12,12 +11,13 @@ use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use crate::batch::Diagnostic;
 use crate::batch::declaration_path::is_declaration_file;
 use crate::batch::error::{CorsaError, CorsaResult};
-use crate::batch::import_rewriter::ImportRewriter;
 use crate::batch::source_map::{CompositeSourceMap, SfcSourceMap};
-use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping};
+use crate::virtual_ts::VizeMapping;
 
+mod context;
 mod css_modules;
 pub(super) use super::paths::source_type_for_path;
+pub(super) use context::{ScriptBuildContext, VirtualBuildContext};
 pub(super) use css_modules::virtual_ts_options_for_descriptor;
 
 use super::VirtualFile;
@@ -27,7 +27,6 @@ use super::javascript_sfc::descriptor_is_unchecked_javascript;
 pub(super) use super::javascript_sfc::descriptor_uses_jsx_script;
 use super::jsx_build::build_jsx_registered_file;
 use super::passthrough::collect_passthrough_modules;
-use super::setup_props::RuntimePropResolveCache;
 use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtual_ts};
 
 pub(super) const VUE_JSX_REFERENCE_DIRECTIVE: &str = "/// <reference types=\"vue/jsx\" />\n";
@@ -48,26 +47,6 @@ pub(super) struct RegisteredFile {
     pub(super) unchecked_javascript: bool,
 }
 
-#[derive(Clone, Copy)]
-pub(super) struct VirtualBuildContext<'a> {
-    pub(super) project_root: &'a Path,
-    pub(super) virtual_root: &'a Path,
-    pub(super) virtual_ts_options: &'a VirtualTsOptions,
-    pub(super) virtual_ts_check_options: VirtualTsCheckOptions,
-    pub(super) preserve_unused_diagnostics: bool,
-    pub(super) options_api: bool,
-    pub(super) legacy_vue2: bool,
-    pub(super) jsx_typecheck: bool,
-    pub(super) dialect: vize_carton::config::VueVersion,
-    pub(super) template_syntax: TemplateSyntaxMode,
-    pub(super) experimental_in_tag_comments: bool,
-    pub(super) hoist_shared_preamble: bool,
-    pub(super) preserve_relative_declarations: bool,
-    pub(super) preserve_declaration_spelling: bool,
-    pub(super) rewriter: &'a ImportRewriter,
-    pub(super) runtime_prop_resolve_cache: Option<&'a RuntimePropResolveCache>,
-}
-
 pub(super) fn build_registered_file(
     path: &Path,
     content: &str,
@@ -82,10 +61,7 @@ pub(super) fn build_registered_file(
             path,
             content,
             SourceType::ts(),
-            (context.project_root, context.virtual_root),
-            context.rewriter,
-            context.preserve_relative_declarations,
-            context.preserve_declaration_spelling,
+            context.script_context(),
         );
     }
 
@@ -102,15 +78,7 @@ pub(super) fn build_registered_file(
     let source_type = source_type_for_path(path).ok_or_else(|| CorsaError::PathError {
         path: path.to_path_buf(),
     })?;
-    build_script_registered_file(
-        path,
-        content,
-        source_type,
-        (context.project_root, context.virtual_root),
-        context.rewriter,
-        context.preserve_relative_declarations,
-        context.preserve_declaration_spelling,
-    )
+    build_script_registered_file(path, content, source_type, context.script_context())
 }
 
 pub(super) fn build_vue_registered_file(
@@ -176,7 +144,13 @@ pub(super) fn build_vue_registered_file(
     }
     let rewritten = profile!(
         "canon.import.rewrite.vue",
-        context.rewriter.rewrite(&code, source_type, path.parent())
+        context.rewriter.rewrite_generated_for_virtual_project(
+            &code,
+            source_type,
+            (context.project_root, context.virtual_root),
+            path.parent(),
+            context.mirrorable_project_files,
+        )
     );
     let source_map = CompositeSourceMap::new_vue(
         SfcSourceMap::new_with_semantic_links(
@@ -227,22 +201,36 @@ pub(super) fn build_script_registered_file(
     path: &Path,
     content: &str,
     source_type: SourceType,
-    roots: (&Path, &Path),
-    rewriter: &ImportRewriter,
-    preserve_relative_declarations: bool,
-    preserve_declaration_spelling: bool,
+    context: ScriptBuildContext<'_>,
 ) -> CorsaResult<RegisteredFile> {
     let rewritten = profile!("canon.import.rewrite.script", {
-        if preserve_relative_declarations {
-            rewriter.rewrite_for_package_shadow(content, source_type, roots, path.parent())
+        if context.preserve_relative_declarations {
+            context.rewriter.rewrite_for_package_shadow(
+                content,
+                source_type,
+                context.roots,
+                path.parent(),
+            )
         } else {
-            rewriter.rewrite_for_virtual_project(content, source_type, roots, path.parent())
+            context
+                .rewriter
+                .rewrite_for_virtual_project_with_mirrorable_files(
+                    content,
+                    source_type,
+                    context.roots,
+                    path.parent(),
+                    context.mirrorable_project_files,
+                )
         }
     });
-    let preserve_declaration_spelling =
-        preserve_declaration_spelling || should_preserve_esm_declaration_spelling(path, content);
-    let virtual_path =
-        super::paths::script_virtual_path(roots, path, content, preserve_declaration_spelling)?;
+    let preserve_declaration_spelling = context.preserve_declaration_spelling
+        || should_preserve_esm_declaration_spelling(path, content);
+    let virtual_path = super::paths::script_virtual_path(
+        context.roots,
+        path,
+        content,
+        preserve_declaration_spelling,
+    )?;
 
     Ok(RegisteredFile {
         file: VirtualFile {
@@ -253,7 +241,12 @@ pub(super) fn build_script_registered_file(
         },
         extra_virtual_files: Vec::new(),
         original_content: content.to_compact_string(),
-        passthrough_files: collect_passthrough_modules(path, content, roots.0, roots.1),
+        passthrough_files: collect_passthrough_modules(
+            path,
+            content,
+            context.roots.0,
+            context.roots.1,
+        ),
         diagnostics: Vec::new(),
         unchecked_javascript: false,
     })

--- a/crates/vize_canon/src/batch/virtual_project/build/context.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build/context.rs
@@ -1,0 +1,52 @@
+use std::path::{Path, PathBuf};
+
+use vize_atelier_core::TemplateSyntaxMode;
+use vize_carton::FxHashSet;
+
+use crate::batch::import_rewriter::ImportRewriter;
+use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
+
+use super::super::setup_props::RuntimePropResolveCache;
+
+#[derive(Clone, Copy)]
+pub(in crate::batch::virtual_project) struct ScriptBuildContext<'a> {
+    pub(in crate::batch::virtual_project) roots: (&'a Path, &'a Path),
+    pub(in crate::batch::virtual_project) rewriter: &'a ImportRewriter,
+    pub(in crate::batch::virtual_project) preserve_relative_declarations: bool,
+    pub(in crate::batch::virtual_project) preserve_declaration_spelling: bool,
+    pub(in crate::batch::virtual_project) mirrorable_project_files: Option<&'a FxHashSet<PathBuf>>,
+}
+
+#[derive(Clone, Copy)]
+pub(in crate::batch::virtual_project) struct VirtualBuildContext<'a> {
+    pub(in crate::batch::virtual_project) project_root: &'a Path,
+    pub(in crate::batch::virtual_project) virtual_root: &'a Path,
+    pub(in crate::batch::virtual_project) virtual_ts_options: &'a VirtualTsOptions,
+    pub(in crate::batch::virtual_project) virtual_ts_check_options: VirtualTsCheckOptions,
+    pub(in crate::batch::virtual_project) preserve_unused_diagnostics: bool,
+    pub(in crate::batch::virtual_project) options_api: bool,
+    pub(in crate::batch::virtual_project) legacy_vue2: bool,
+    pub(in crate::batch::virtual_project) jsx_typecheck: bool,
+    pub(in crate::batch::virtual_project) dialect: vize_carton::config::VueVersion,
+    pub(in crate::batch::virtual_project) template_syntax: TemplateSyntaxMode,
+    pub(in crate::batch::virtual_project) experimental_in_tag_comments: bool,
+    pub(in crate::batch::virtual_project) hoist_shared_preamble: bool,
+    pub(in crate::batch::virtual_project) preserve_relative_declarations: bool,
+    pub(in crate::batch::virtual_project) preserve_declaration_spelling: bool,
+    pub(in crate::batch::virtual_project) mirrorable_project_files: Option<&'a FxHashSet<PathBuf>>,
+    pub(in crate::batch::virtual_project) rewriter: &'a ImportRewriter,
+    pub(in crate::batch::virtual_project) runtime_prop_resolve_cache:
+        Option<&'a RuntimePropResolveCache>,
+}
+
+impl<'a> VirtualBuildContext<'a> {
+    pub(in crate::batch::virtual_project) fn script_context(self) -> ScriptBuildContext<'a> {
+        ScriptBuildContext {
+            roots: (self.project_root, self.virtual_root),
+            rewriter: self.rewriter,
+            preserve_relative_declarations: self.preserve_relative_declarations,
+            preserve_declaration_spelling: self.preserve_declaration_spelling,
+            mirrorable_project_files: self.mirrorable_project_files,
+        }
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -19,8 +19,8 @@ mod config;
 mod package_routes;
 
 use super::build::{
-    RegisteredFile, VirtualBuildContext, build_registered_file, build_script_registered_file,
-    build_vue_registered_file, source_type_for_path,
+    RegisteredFile, ScriptBuildContext, VirtualBuildContext, build_registered_file,
+    build_script_registered_file, build_vue_registered_file, source_type_for_path,
 };
 use super::setup_props::RuntimePropResolveCache;
 use super::{VirtualProject, project_virtual_root};
@@ -127,6 +127,7 @@ impl VirtualProject {
                 hoist_shared_preamble: true,
                 preserve_relative_declarations: package_route_path,
                 preserve_declaration_spelling: self.session_scripts,
+                mirrorable_project_files: None,
                 rewriter: &self.rewriter,
                 runtime_prop_resolve_cache: None,
             },
@@ -165,6 +166,11 @@ impl VirtualProject {
 
         let preserve_unused_diagnostics = self.tsconfig_preserves_unused_diagnostics();
         let runtime_prop_resolve_cache = RuntimePropResolveCache::default();
+        let mut mirrorable_project_files: FxHashSet<PathBuf> = valid_paths
+            .iter()
+            .map(|path| vize_carton::path::canonicalize_non_verbatim(path))
+            .collect();
+        mirrorable_project_files.extend(self.original_index.keys().cloned());
         let build_context = VirtualBuildContext {
             project_root: self.project_root.as_path(),
             virtual_root: self.virtual_root.as_path(),
@@ -180,6 +186,7 @@ impl VirtualProject {
             hoist_shared_preamble: true,
             preserve_relative_declarations: false,
             preserve_declaration_spelling: self.session_scripts,
+            mirrorable_project_files: Some(&mirrorable_project_files),
             rewriter: &self.rewriter,
             runtime_prop_resolve_cache: Some(&runtime_prop_resolve_cache),
         };
@@ -227,6 +234,7 @@ impl VirtualProject {
                 hoist_shared_preamble: true,
                 preserve_relative_declarations: self.is_package_route_path(path),
                 preserve_declaration_spelling: self.session_scripts,
+                mirrorable_project_files: None,
                 rewriter: &self.rewriter,
                 runtime_prop_resolve_cache: None,
             },
@@ -260,10 +268,13 @@ impl VirtualProject {
             path,
             content,
             source_type,
-            (&self.project_root, &self.virtual_root),
-            &self.rewriter,
-            self.is_package_route_path(path),
-            self.session_scripts,
+            ScriptBuildContext {
+                roots: (&self.project_root, &self.virtual_root),
+                rewriter: &self.rewriter,
+                preserve_relative_declarations: self.is_package_route_path(path),
+                preserve_declaration_spelling: self.session_scripts,
+                mirrorable_project_files: None,
+            },
         )?;
         self.absorb_registered_file(registered);
         Ok(())

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |          1136 |                   787 |               349 |             158 |     373 |            1009 |      658 |           561 |           700 |
 | Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           569 |
-| Typechecker                |           927 |                   256 |               671 |             414 |     214 |             869 |      686 |           501 |           716 |
+| Typechecker                |           934 |                   256 |               678 |             414 |     214 |             875 |      687 |           504 |           720 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |
 | LSP                        |           301 |                   301 |                 0 |             115 |      47 |             349 |      114 |           174 |           410 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         927 |             527 |      400 |
+| S0               |         934 |             533 |      401 |
 | old AST/parser   |         166 |              37 |      129 |
 | Croquis analysis |         248 |             127 |      121 |
 | raw OXC          |         214 |             178 |       36 |
@@ -149,7 +149,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 | `crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs:7` | source   | S0 10                                                       |    10 |
 | `crates/vize_canon/src/virtual_ts/scope/context.rs:3`                          | source   | S0 4<br>old AST/parser 2<br>Croquis analysis 3              |     9 |
 
-Additional source/manifest rows are in the TSV: 332 omitted.
+Additional source/manifest rows are in the TSV: 334 omitted.
 
 #### Top test/dev files
 
@@ -161,7 +161,7 @@ Additional source/manifest rows are in the TSV: 332 omitted.
 | `crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs:1`                    | test/dev | S0 8<br>old AST/parser 8<br>Croquis analysis 1    |    17 |
 | `crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs:3`                        | test/dev | S0 8<br>old AST/parser 7<br>Croquis analysis 1    |    16 |
 
-Additional test/dev rows are in the TSV: 197 omitted.
+Additional test/dev rows are in the TSV: 198 omitted.
 
 ### Typechecker content-mapper
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1808,6 +1808,7 @@ typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_colle
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_dts_tests.rs	5	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_dts.rs	13	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_policy.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_project_mirror.rs	6	s0	S0	stage	vize_carton	compat	6
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_source_map.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_tests.rs	5	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_virtual_tests.rs	5	s0	S0	stage	vize_carton	compat	1
@@ -1816,7 +1817,7 @@ typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtu
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtual.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtual.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_virtual.rs	204	s0	S0	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
@@ -1855,6 +1856,7 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/generic_emit_guard.rs	6	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_component_callbacks.rs	49	s0	S0	stage	vize_s0	preferred	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_html_fallthrough_attrs.rs	21	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/large_declaration_identity.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/literal_union_props.rs	7	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs	21	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/single_required_camel_prop.rs	4	s0	S0	stage	vize_s0	preferred	1
@@ -1876,7 +1878,8 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project.rs	21	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project.rs	268	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/art_usage.rs	5	s0	S0	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build.rs	8	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build/context.rs	4	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build/css_modules.rs	6	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/css_var_usage.rs	20	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/css_var_usage.rs	20	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -1933,7 +1936,7 @@ typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths/commonjs_declaration.rs	20	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths/commonjs_declaration.rs	20	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths/commonjs_declaration.rs	20	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project.rs	11	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project.rs	11	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/artifacts.rs	109	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/config.rs	41	s0	S0	stage	vize_carton	compat	5
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/package_routes.rs	5	s0	S0	stage	vize_carton	compat	5


### PR DESCRIPTION
## Summary
- keep mirrored declaration files on a single virtual-project module identity when a scanned project file is imported through both an alias and an absolute project path
- pass the mirrorable project file set into virtual-project import rewrites
- add a regression fixture for the duplicate declaration identity diagnostic from #6000

## Tests
- cargo test -p vize_canon import_rewriter -- --nocapture
- cargo test -p vize_canon aliased_large_declaration_module_and_absolute_import_share_identity -- --nocapture
- cargo test -p vize_canon materialized_project_keeps_generated_graphql_schema_on_real_path -- --nocapture
- cargo fmt --all --check
- git diff --check origin/main...HEAD
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5

Fixes #6000

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791628556&installation_model_id=422833&pr_number=6023&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6023&signature=46ba42f062f3f511c15734d0065bb742fa36df143de2df3afdf369d161174799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual-project import resolution for Vue and TypeScript files, including absolute imports, relative declaration references, and mirrored project files.
  * Preserved consistent module identity when the same declaration is referenced through an alias and an absolute path.
  * Improved handling of Vue source files during virtual-project generation.

* **Refactor**
  * Reorganized virtual-project build context and import-rewriting logic for more reliable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->