### PR TITLE
fix(nuxt): recognize rolldown-vite compiler builder

### DIFF
--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -51,6 +51,22 @@ Nuxt.
 During development, the server response cleanup preserves valid URL-encoded Nuxt asset links such
 as `%40fs/` and encoded `assets/` paths while dropping decoded null-byte or traversal paths.
 
+To verify that Vize, not Nuxt's host Vue compiler, handled an SFC, enable compiler debug logging:
+
+```ts
+export default defineNuxtConfig({
+  modules: ["@vizejs/nuxt"],
+  vize: {
+    compiler: { debug: true },
+  },
+});
+```
+
+Nuxt defaults to on-demand SFC compilation, so debug builds print `[vize] load: on-demand compiling
+...` only for files that actually enter the compiler pipeline. Published `@vizejs/nuxt` packages pin
+`vize`, `@vizejs/vite-plugin`, `@vizejs/native`, and the sibling Vize packages to the same release
+version.
+
 ## Module Options
 
 `@vizejs/nuxt` keeps the simple `compiler: true | false` switch, but the module options also expose

--- a/npm/framework/nuxt/src/builder.test.ts
+++ b/npm/framework/nuxt/src/builder.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getNuxtBuilderKind, isViteNuxtBuilder, isWebpackNuxtBuilder } from "./builder.ts";
+
+void test("Nuxt rolldown-vite builder is treated as Vite-compatible", () => {
+  assert.equal(isViteNuxtBuilder("rolldown-vite"), true);
+  assert.equal(isViteNuxtBuilder("@nuxt/rolldown-vite-builder"), true);
+  assert.equal(getNuxtBuilderKind("rolldown-vite"), "vite");
+});
+
+void test("Nuxt classic Vite and webpack builder names keep their existing classification", () => {
+  assert.equal(isViteNuxtBuilder("vite"), true);
+  assert.equal(isViteNuxtBuilder("@nuxt/vite-builder"), true);
+  assert.equal(isWebpackNuxtBuilder("webpack"), true);
+  assert.equal(isWebpackNuxtBuilder("@nuxt/webpack-builder"), true);
+  assert.equal(getNuxtBuilderKind("@nuxt/webpack-builder"), "webpack");
+});
+
+void test("unknown or missing Nuxt builders stay unsupported", () => {
+  assert.equal(isViteNuxtBuilder("custom-builder"), false);
+  assert.equal(isWebpackNuxtBuilder("custom-builder"), false);
+  assert.equal(getNuxtBuilderKind("custom-builder"), "unsupported");
+  assert.equal(getNuxtBuilderKind(undefined), "unsupported");
+});

--- a/npm/framework/nuxt/src/builder.ts
+++ b/npm/framework/nuxt/src/builder.ts
@@ -1,0 +1,30 @@
+export type NuxtBuilderKind = "unsupported" | "vite" | "webpack";
+
+export function isViteNuxtBuilder(builder: unknown): boolean {
+  if (typeof builder !== "string") {
+    return false;
+  }
+  return (
+    builder === "vite" ||
+    builder.includes("vite-builder") ||
+    builder === "rolldown-vite" ||
+    builder.includes("rolldown-vite-builder")
+  );
+}
+
+export function isWebpackNuxtBuilder(builder: unknown): boolean {
+  if (typeof builder !== "string") {
+    return false;
+  }
+  return builder === "webpack" || builder.includes("webpack-builder");
+}
+
+export function getNuxtBuilderKind(builder: unknown): NuxtBuilderKind {
+  if (isViteNuxtBuilder(builder)) {
+    return "vite";
+  }
+  if (isWebpackNuxtBuilder(builder)) {
+    return "webpack";
+  }
+  return "unsupported";
+}

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -8,6 +8,7 @@ import { patchNuxtClientManifestCloseBundlePlugin } from "./client-manifest-brid
 import { patchNuxtHostVuePluginForCompilerExcludes } from "./host-vue-bridge";
 import { patchNuxtKeyedFunctionsPlugin, type ViteTransformResult } from "./keyed-functions-bridge";
 import "./schema";
+import { isViteNuxtBuilder } from "./builder";
 import * as bridgeFastPath from "./bridge-fast-path";
 import type { VizeNuxtCompilerOptions, VizeNuxtOptions } from "./options";
 import {
@@ -162,15 +163,12 @@ function getDetectedNuxtMajor(nuxt: unknown): 2 | 3 | 4 | null {
 }
 
 function hasNuxtViteCompilerSupport(nuxt: NuxtWithBuilderOptions): boolean {
-  const builder = nuxt.options.builder;
-  if (typeof builder === "string") {
-    return builder === "vite" || builder.includes("vite-builder");
+  if (isViteNuxtBuilder(nuxt.options.builder)) {
+    return true;
   }
-
   if (nuxt.options.vite) {
     return true;
   }
-
   return getDetectedNuxtMajor(nuxt) !== 2;
 }
 

--- a/npm/framework/nuxt/src/lint/checker/setup.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/setup.test.ts
@@ -68,6 +68,18 @@ void test("setup connects the generated config seam to the Vite addon", async ()
   });
 });
 
+void test("setup treats Nuxt rolldown-vite as a Vite checker host", async () => {
+  let registered = false;
+  const result = await setupNuxtLintChecker(true, nuxt({ builder: "rolldown-vite" }), generation, {
+    addVitePlugin: async () => {
+      registered = true;
+    },
+  });
+
+  assert.equal(result?.builder, "vite");
+  assert.equal(registered, true);
+});
+
 void test("setup connects every explicit option to the webpack addon", async () => {
   let registered: unknown;
   const result = await setupNuxtLintChecker(

--- a/npm/framework/nuxt/src/lint/checker/setup.ts
+++ b/npm/framework/nuxt/src/lint/checker/setup.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 
+import { getNuxtBuilderKind } from "../../builder.ts";
 import type { NuxtLintConfigGeneration } from "../generation.ts";
 import {
   resolveNuxtLintCheckerOptions,
@@ -51,13 +52,6 @@ async function addWebpackPlugin(plugin: NuxtLintCheckerWebpackPlugin): Promise<v
   kit.addWebpackPlugin(plugin, { server: false });
 }
 
-function builderKind(builder: unknown): "unsupported" | "vite" | "webpack" {
-  if (typeof builder !== "string") return "unsupported";
-  if (builder === "vite" || builder.includes("vite-builder")) return "vite";
-  if (builder === "webpack" || builder.includes("webpack-builder")) return "webpack";
-  return "unsupported";
-}
-
 /** Register the dev-only adapter over Phase 3's generated config artifact. */
 export async function setupNuxtLintChecker(
   checker: boolean | VizeNuxtLintCheckerOptions | undefined,
@@ -78,7 +72,7 @@ export async function setupNuxtLintChecker(
   if (options === false) return undefined;
   const rootDir = path.resolve(nuxt.options.rootDir);
   const config = { configFile: generation.configFile, options, rootDir };
-  const builder = builderKind(nuxt.options.builder);
+  const builder = getNuxtBuilderKind(nuxt.options.builder);
 
   if (builder === "vite") {
     const register = dependencies.addVitePlugin ?? addVitePlugin;


### PR DESCRIPTION
## Summary
- classify Nuxt's rolldown-vite builder as Vite-compatible so @vizejs/nuxt keeps the compiler bridge active under Nuxt 4 rolldown-vite builds
- share the Nuxt builder classifier with the dev lint checker
- document compiler debug logging for verifying that SFCs enter the Vize pipeline and clarify that published Vize packages are pinned to the same release line

## Tests
- node --test npm/framework/nuxt/src/builder.test.ts npm/framework/nuxt/src/lint/checker/setup.test.ts
- git diff --check origin/main...HEAD
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- npm view @vizejs/nuxt@0.404.14 version dependencies peerDependencies --json
- npm view @vizejs/nuxt@0.405.0 version dependencies peerDependencies --json

Fixes #6002

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791629290&installation_model_id=422833&pr_number=6024&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6024&signature=2536949bd3712e8a1f83dfcad939f0bdd518dfa88c4f21da85a468fd4d82545e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Nuxt projects using the `rolldown-vite` builder, including compiler and lint checker integration.
  - Existing Vite and webpack builder support remains available.

- **Documentation**
  - Added guidance for enabling Nuxt compiler debug logging and interpreting on-demand compilation output.
  - Documented that published Nuxt integration packages use matching release versions for Vize and related packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->