### PR TITLE
test(ui): audit toolchain testbed gates

### DIFF
--- a/npm/ui/src/authoring/toolchain-testbed.behavior.md
+++ b/npm/ui/src/authoring/toolchain-testbed.behavior.md
@@ -4,8 +4,10 @@ Normative state × input → outcome table for the UI source corpus used by
 Atelier, Patina, Glyph, and Canon. Every row is proven by the named test in
 `src/authoring/toolchain-testbed.test.ts` or by the package `check` script itself.
 
-| #   | State          | Input                  | Outcome                                                              | Proven by                                                        |
-| --- | -------------- | ---------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| T1  | package script | `pnpm check`           | SFC lint and DOM/SSR/Vapor renderer compilation run before typecheck | `package check keeps the UI source corpus on the toolchain gate` |
-| T2  | renderer gate  | authored Vue SFC files | DOM, SSR, and Vapor lanes compile every source fixture               | `pnpm lint:sfc`                                                  |
-| T3  | linter gate    | authored Vue SFC files | opinionated SFC authoring rules run on every source fixture          | `pnpm lint:sfc`                                                  |
+| #   | State          | Input                     | Outcome                                                                  | Proven by                                                              |
+| --- | -------------- | ------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| T1  | package script | `pnpm check`              | SFC lint and DOM/SSR/Vapor renderer compilation run before typecheck     | `package check keeps the UI source corpus on the toolchain gate`       |
+| T2  | formatter gate | `pnpm fmt`                | source, scripts, and Vite config stay on the same package-local fmt lane | `package check keeps the UI source corpus on the toolchain gate`       |
+| T3  | renderer gate  | authored Vue SFC files    | DOM, SSR, and Vapor lanes compile every source fixture                   | `renderer conformance script owns the DOM, SSR, and Vapor lanes`       |
+| T4  | linter gate    | authored Vue SFC files    | opinionated type-aware Patina authoring rules run on every source SFC    | `sfc lint script owns the Patina opinionated authoring lane`           |
+| T5  | typecheck gate | catalogued type contracts | compile-only public contracts remain included by the static check lane   | `static typecheck keeps catalogued public contracts on the Canon lane` |

--- a/npm/ui/src/authoring/toolchain-testbed.test.ts
+++ b/npm/ui/src/authoring/toolchain-testbed.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import ts from "typescript";
 import { test } from "vite-plus/test";
+
+import { uiFamilyCatalog } from "../catalog/family-catalog.ts";
 
 test("package check keeps the UI source corpus on the toolchain gate", async () => {
   const manifest = JSON.parse(await readFile(path.resolve("package.json"), "utf8")) as {
@@ -15,6 +18,7 @@ test("package check keeps the UI source corpus on the toolchain gate", async () 
   );
   assert.equal(manifest.scripts.check, "pnpm lint:sfc && pnpm check:static");
   assert.match(manifest.scripts["check:static"], /vue-tsc --noEmit -p tsconfig\.typecheck\.json/);
+  assert.equal(manifest.scripts.fmt, "vp fmt --write src scripts vite.config.ts");
 });
 
 test("renderer conformance script owns the DOM, SSR, and Vapor lanes", async () => {
@@ -26,3 +30,68 @@ test("renderer conformance script owns the DOM, SSR, and Vapor lanes", async () 
   assert.ok(checkRendererSource.includes("compileSfc"));
   assert.ok(checkRendererSource.includes("sourceFiles.length + inlineFixtures.length"));
 });
+
+test("sfc lint script owns the Patina opinionated authoring lane", async () => {
+  const packageLintSource = await readFile(path.resolve("scripts/lint-sfc.ts"), "utf8");
+  const sharedLintSource = await readFile(
+    path.resolve("scripts/source-quality/lint-sfc.ts"),
+    "utf8",
+  );
+
+  assert.ok(packageLintSource.includes("lintPatinaSfc"));
+  assert.ok(packageLintSource.includes("runSfcLintCli"));
+  assert.ok(sharedLintSource.includes('preset: "opinionated"'));
+  assert.ok(sharedLintSource.includes("typeAware: true"));
+  assert.ok(sharedLintSource.includes('helpLevel: "short"'));
+  assert.ok(sharedLintSource.includes('entry.name.endsWith(".vue")'));
+  assert.ok(sharedLintSource.includes("[...new Set(discovered.flat())].sort()"));
+});
+
+test("static typecheck keeps catalogued public contracts on the Canon lane", async () => {
+  const tsconfig = JSON.parse(await readFile(path.resolve("tsconfig.typecheck.json"), "utf8")) as {
+    readonly include: readonly string[];
+    readonly exclude: readonly string[];
+    readonly compilerOptions: { readonly noEmit: boolean };
+  };
+
+  assert.equal(tsconfig.compilerOptions.noEmit, true);
+  assert.deepEqual(tsconfig.include, ["src/**/*.ts", "src/**/*.vue"]);
+
+  const typeTestFiles = uiFamilyCatalog.flatMap((entry) => entry.typeTests ?? []);
+  const parsedConfig = parseTypecheckConfig();
+  const program = ts.createProgram({
+    rootNames: parsedConfig.fileNames,
+    options: parsedConfig.options,
+  });
+  const programFiles = new Set(
+    [...program.getRootFileNames(), ...program.getSourceFiles().map((file) => file.fileName)].map(
+      (file) => path.resolve(file),
+    ),
+  );
+
+  assert.ok(typeTestFiles.length >= 70, "catalogued families must publish compile-only contracts");
+  for (const file of typeTestFiles) {
+    assert.ok(file.endsWith(".types.test-d.ts"), `${file} must be a compile-only type contract`);
+    await readFile(path.resolve(file), "utf8");
+    assert.ok(
+      programFiles.has(path.resolve(file)),
+      `${file} must be included in the resolved tsconfig.typecheck.json program`,
+    );
+  }
+});
+
+function parseTypecheckConfig() {
+  const configPath = path.resolve("tsconfig.typecheck.json");
+  const config = ts.readConfigFile(configPath, (fileName) => ts.sys.readFile(fileName));
+  assert.equal(config.error, undefined);
+
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    path.dirname(configPath),
+    undefined,
+    configPath,
+  );
+  assert.deepEqual(parsed.errors, []);
+  return parsed;
+}


### PR DESCRIPTION
Refs #4899

## Summary
- pin the UI package scripts that route formatter, SFC lint, renderer, and typecheck gates
- assert the Patina opinionated SFC lint lane and Canon public type contracts stay wired into the testbed
- document the expanded toolchain testbed behavior rows

## Verification
- vp -C npm/ui test run src/authoring/toolchain-testbed.test.ts
- vp -C npm/ui check src/authoring/toolchain-testbed.test.ts src/authoring/toolchain-testbed.behavior.md
- vp -C npm/ui exec vue-tsc --noEmit -p tsconfig.typecheck.json
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791692460&installation_model_id=422833&pr_number=6030&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6030&signature=6d81087b429b6bc31d87ba8986e252de5da5df2912cc2d5581b1f6ed757431f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the authoring toolchain behavior contract to cover formatting, rendering, linting, and type-checking gates.
  - Clarified that type-aware authoring rules are applied across source components.

- **Tests**
  - Added coverage for formatting configuration and linting behavior.
  - Added validation for type-checking settings and catalogued type contracts, including verification that required contract files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->