### PR TITLE
fix(glyph): preserve plain style comments

### DIFF
--- a/crates/vize_glyph/src/style.rs
+++ b/crates/vize_glyph/src/style.rs
@@ -3,10 +3,12 @@
 //! This module provides formatting for CSS/SCSS/Less content
 //! in Vue SFC `<style>` blocks using lightningcss for parsing and printing.
 
+mod comment_scan;
 mod stabilization;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
+use comment_scan::{SegmentKind, has_nested_comment, split_top_level_comments};
 use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
 use vize_s0::{String, ToCompactString};
 
@@ -14,12 +16,16 @@ use vize_s0::{String, ToCompactString};
 ///
 /// Top-level (depth 0) comments are extracted before parsing and re-inserted
 /// at their original boundaries, because lightningcss drops non-license
-/// comments during parse. Comments nested inside a selector block are still
-/// dropped — that limitation is documented and covered by an ignored test.
+/// comments during parse. Nested comments keep the original block text instead
+/// of risking silent data loss.
 pub fn format_style_content(source: &str, options: &FormatOptions) -> Result<String, FormatError> {
     let trimmed = source.trim();
     if trimmed.is_empty() {
         return Ok(String::default());
+    }
+
+    if has_nested_comment(source) {
+        return Ok(trimmed.to_compact_string());
     }
 
     if !contains_comment(source) {
@@ -135,101 +141,6 @@ fn contains_comment(source: &str) -> bool {
     memchr::memmem::find(source.as_bytes(), b"/*").is_some()
 }
 
-#[derive(Clone, Copy)]
-enum SegmentKind {
-    Code,
-    Comment,
-}
-
-struct CssSegment<'a> {
-    kind: SegmentKind,
-    content: &'a str,
-}
-
-/// Split CSS source into alternating code and top-level comment segments.
-///
-/// Only depth-0 comments (those outside `{ ... }` and not inside a string
-/// literal) become separate `Comment` segments. Comments nested in a selector
-/// block stay embedded in the surrounding `Code` segment, because slicing the
-/// rule at that point would produce text lightningcss could not parse.
-fn split_top_level_comments(source: &str) -> Vec<CssSegment<'_>> {
-    let bytes = source.as_bytes();
-    let mut segments: Vec<CssSegment<'_>> = Vec::new();
-    let mut depth: u32 = 0;
-    let mut in_string: Option<u8> = None;
-    let mut last_split = 0usize;
-    let mut i = 0usize;
-
-    while i < bytes.len() {
-        let c = bytes[i];
-
-        if let Some(quote) = in_string {
-            if c == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-                continue;
-            }
-            if c == quote {
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-
-        match c {
-            b'"' | b'\'' => {
-                in_string = Some(c);
-                i += 1;
-            }
-            b'{' => {
-                depth = depth.saturating_add(1);
-                i += 1;
-            }
-            b'}' => {
-                depth = depth.saturating_sub(1);
-                i += 1;
-            }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
-                let comment_end = find_comment_end(bytes, i + 2);
-                if depth == 0 {
-                    if i > last_split {
-                        segments.push(CssSegment {
-                            kind: SegmentKind::Code,
-                            content: &source[last_split..i],
-                        });
-                    }
-                    segments.push(CssSegment {
-                        kind: SegmentKind::Comment,
-                        content: &source[i..comment_end],
-                    });
-                    last_split = comment_end;
-                }
-                i = comment_end;
-            }
-            _ => i += 1,
-        }
-    }
-
-    if last_split < bytes.len() {
-        segments.push(CssSegment {
-            kind: SegmentKind::Code,
-            content: &source[last_split..],
-        });
-    }
-
-    segments
-}
-
-fn find_comment_end(bytes: &[u8], from: usize) -> usize {
-    let mut j = from;
-    while j + 1 < bytes.len() {
-        if bytes[j] == b'*' && bytes[j + 1] == b'/' {
-            return j + 2;
-        }
-        j += 1;
-    }
-    bytes.len()
-}
-
 #[cfg(test)]
 mod tests {
     use super::{FormatOptions, format_style_content};
@@ -319,6 +230,27 @@ mod tests {
     }
 
     #[test]
+    fn test_format_preserves_nested_block_comments_by_leaving_block_raw() {
+        let source = concat!(
+            ".box {\n",
+            "  /* keep color note */\n",
+            "  color: red;\n",
+            "  /* keep nested note */\n",
+            "  .inner {\n",
+            "    color: blue; /* keep inline note */\n",
+            "  }\n",
+            "}\n",
+        );
+        let options = FormatOptions::default();
+        let result = format_style_content(source, &options).unwrap();
+
+        assert_eq!(result.as_str(), source.trim());
+        assert!(result.contains("/* keep color note */"));
+        assert!(result.contains("/* keep nested note */"));
+        assert!(result.contains("/* keep inline note */"));
+    }
+
+    #[test]
     fn test_format_keeps_comment_like_content_inside_strings_as_string() {
         let source = ".x { content: \"/* not a comment */\"; }";
         let options = FormatOptions::default();
@@ -327,6 +259,35 @@ mod tests {
         // lightningcss emits a clean single-rule output.
         assert!(result.contains(".x"));
         assert!(result.contains("\"/* not a comment */\""));
+    }
+
+    #[test]
+    fn test_format_keeps_comment_markers_inside_unquoted_urls() {
+        let source = concat!(
+            ".asset{background:url(https://example.test/a/*/icon.svg);color:red}\n",
+            "/* after */",
+        );
+        let options = FormatOptions::default();
+        let result = format_style_content(source, &options).unwrap();
+
+        assert!(result.contains(".asset {\n"));
+        assert!(result.contains("https://example.test/a/*/icon.svg"));
+        assert!(result.contains("/* after */"));
+    }
+
+    #[test]
+    fn test_format_splits_top_level_comments_after_import_url_data() {
+        let source = concat!(
+            "@import url(https://example.test/a/*/reset.css);\n",
+            "/* import note */\n",
+            ".asset{color:red}",
+        );
+        let options = FormatOptions::default();
+        let result = format_style_content(source, &options).unwrap();
+
+        assert!(result.contains("https://example.test/a/*/reset.css"));
+        assert!(result.contains("/* import note */"));
+        assert!(result.contains(".asset {\n"));
     }
 
     #[test]

--- a/crates/vize_glyph/src/style/comment_scan.rs
+++ b/crates/vize_glyph/src/style/comment_scan.rs
@@ -1,0 +1,278 @@
+pub(super) fn has_nested_comment(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut depth: u32 = 0;
+    let mut in_string: Option<u8> = None;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        if let Some(quote) = in_string {
+            if let Some(next) = consume_css_escape(bytes, i) {
+                i = next;
+                continue;
+            }
+            if c == quote {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+
+        if let Some(next) = consume_css_escape(bytes, i) {
+            i = next;
+            continue;
+        }
+
+        if let Some(next) = consume_unquoted_url(bytes, i) {
+            i = next;
+            continue;
+        }
+
+        match c {
+            b'"' | b'\'' => {
+                in_string = Some(c);
+                i += 1;
+            }
+            b'{' => {
+                depth = depth.saturating_add(1);
+                i += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                if depth > 0 {
+                    return true;
+                }
+                i = find_comment_end(bytes, i + 2);
+            }
+            _ => i += 1,
+        }
+    }
+
+    false
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum SegmentKind {
+    Code,
+    Comment,
+}
+
+pub(super) struct CssSegment<'a> {
+    pub(super) kind: SegmentKind,
+    pub(super) content: &'a str,
+}
+
+/// Split CSS source into alternating code and top-level comment segments.
+pub(super) fn split_top_level_comments(source: &str) -> Vec<CssSegment<'_>> {
+    let bytes = source.as_bytes();
+    let mut segments: Vec<CssSegment<'_>> = Vec::new();
+    let mut depth: u32 = 0;
+    let mut in_string: Option<u8> = None;
+    let mut last_split = 0usize;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+
+        if let Some(quote) = in_string {
+            if let Some(next) = consume_css_escape(bytes, i) {
+                i = next;
+                continue;
+            }
+            if c == quote {
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+
+        if let Some(next) = consume_css_escape(bytes, i) {
+            i = next;
+            continue;
+        }
+
+        if let Some(next) = consume_unquoted_url(bytes, i) {
+            i = next;
+            continue;
+        }
+
+        match c {
+            b'"' | b'\'' => {
+                in_string = Some(c);
+                i += 1;
+            }
+            b'{' => {
+                depth = depth.saturating_add(1);
+                i += 1;
+            }
+            b'}' => {
+                depth = depth.saturating_sub(1);
+                i += 1;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                let comment_end = find_comment_end(bytes, i + 2);
+                if depth == 0 {
+                    if i > last_split {
+                        segments.push(CssSegment {
+                            kind: SegmentKind::Code,
+                            content: &source[last_split..i],
+                        });
+                    }
+                    segments.push(CssSegment {
+                        kind: SegmentKind::Comment,
+                        content: &source[i..comment_end],
+                    });
+                    last_split = comment_end;
+                }
+                i = comment_end;
+            }
+            _ => i += 1,
+        }
+    }
+
+    if last_split < bytes.len() {
+        segments.push(CssSegment {
+            kind: SegmentKind::Code,
+            content: &source[last_split..],
+        });
+    }
+
+    segments
+}
+
+fn consume_css_escape(bytes: &[u8], from: usize) -> Option<usize> {
+    if bytes.get(from) != Some(&b'\\') {
+        return None;
+    }
+
+    let mut i = from + 1;
+    if i >= bytes.len() {
+        return Some(i);
+    }
+
+    if bytes[i].is_ascii_hexdigit() {
+        let mut digit_count = 0u8;
+        while i < bytes.len() && digit_count < 6 && bytes[i].is_ascii_hexdigit() {
+            i += 1;
+            digit_count += 1;
+        }
+
+        if i < bytes.len() && is_css_whitespace(bytes[i]) {
+            if bytes[i] == b'\r' && i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+
+        return Some(i);
+    }
+
+    if bytes[i] == b'\r' && i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+        return Some(i + 2);
+    }
+
+    Some(i + 1)
+}
+
+fn consume_unquoted_url(bytes: &[u8], from: usize) -> Option<usize> {
+    if from > 0 && is_css_ident_byte(bytes[from - 1]) {
+        return None;
+    }
+    if !starts_with_ascii_case_insensitive(bytes, from, b"url") {
+        return None;
+    }
+
+    let mut i = from + 3;
+    while i < bytes.len() && is_css_whitespace(bytes[i]) {
+        i += 1;
+    }
+    if bytes.get(i) != Some(&b'(') {
+        return None;
+    }
+    i += 1;
+    while i < bytes.len() && is_css_whitespace(bytes[i]) {
+        i += 1;
+    }
+    if matches!(bytes.get(i), Some(b'"' | b'\'')) {
+        return None;
+    }
+
+    while i < bytes.len() {
+        if let Some(next) = consume_css_escape(bytes, i) {
+            i = next;
+            continue;
+        }
+        if bytes[i] == b')' {
+            return Some(i + 1);
+        }
+        i += 1;
+    }
+
+    Some(i)
+}
+
+fn starts_with_ascii_case_insensitive(bytes: &[u8], from: usize, needle: &[u8]) -> bool {
+    bytes
+        .get(from..from + needle.len())
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(needle))
+}
+
+fn is_css_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-'
+}
+
+fn is_css_whitespace(byte: u8) -> bool {
+    matches!(byte, b'\t' | b'\n' | b'\r' | b'\x0c' | b' ')
+}
+
+fn find_comment_end(bytes: &[u8], from: usize) -> usize {
+    let mut j = from;
+    while j + 1 < bytes.len() {
+        if bytes[j] == b'*' && bytes[j + 1] == b'/' {
+            return j + 2;
+        }
+        j += 1;
+    }
+    bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SegmentKind, has_nested_comment, split_top_level_comments};
+
+    #[test]
+    fn css_escapes_do_not_affect_comment_depth() {
+        let escaped_simple = ".escaped\\{name { color: red; }\n/* top-level */";
+        let escaped_hex = ".escaped\\00007b name { color: red; }\n/* top-level */";
+        let escaped_hex_newline = ".escaped\\00007b\nname { color: red; }\n/* top-level */";
+        let escaped_close = ".rule { color: \\}; /* nested */ }\n/* top-level */";
+        let declaration_url = ".asset { background: url(https://example.test/a/*/icon.svg); }";
+        let import_url = "@import url(https://example.test/a/*/reset.css);\n/* top-level */";
+        let unescaped = ".unescaped { color: red; /* nested */ }";
+
+        assert_eq!(has_nested_comment(escaped_simple), false);
+        assert_eq!(has_nested_comment(escaped_hex), false);
+        assert_eq!(has_nested_comment(escaped_hex_newline), false);
+        assert_eq!(has_nested_comment(escaped_close), true);
+        assert_eq!(has_nested_comment(declaration_url), false);
+        assert_eq!(has_nested_comment(import_url), false);
+        assert_eq!(has_nested_comment(unescaped), true);
+
+        assert_eq!(top_level_comment_count(escaped_hex), 1);
+        assert_eq!(top_level_comment_count(escaped_hex_newline), 1);
+        assert_eq!(top_level_comment_count(escaped_close), 1);
+        assert_eq!(top_level_comment_count(import_url), 1);
+    }
+
+    fn top_level_comment_count(source: &str) -> usize {
+        split_top_level_comments(source)
+            .iter()
+            .filter(|segment| matches!(segment.kind, SegmentKind::Comment))
+            .count()
+    }
+}

--- a/crates/vize_glyph/tests/sfc_plain_style_comments.rs
+++ b/crates/vize_glyph/tests/sfc_plain_style_comments.rs
@@ -1,0 +1,26 @@
+use vize_glyph::{FormatOptions, format_sfc};
+
+#[test]
+fn plain_style_preserves_nested_comments() {
+    let source = r#"<template>
+  <div class="box">hello</div>
+</template>
+
+<style scoped>
+.box {
+  /* keep color note */
+  color: red;
+  /* keep nested note */
+  .inner {
+    color: blue; /* keep inline note */
+  }
+}
+</style>
+"#;
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+
+    assert_eq!(first.code, source);
+    assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -49,7 +49,7 @@ observational guard for planning only. It does not change rollout state.
 | Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           569 |
 | Typechecker                |           937 |                   258 |               679 |             416 |     214 |             876 |      691 |           506 |           722 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
-| Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |
+| Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            71 |
 | LSP                        |           301 |                   301 |                 0 |             115 |      47 |             349 |      114 |           174 |           410 |
 
 ## Consumer details

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2708,7 +2708,7 @@ formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	s0	S
 formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	raw_oxc	raw OXC	raw	oxc_formatter	raw	1
-formatter	Formatter	source	crates/vize_glyph/src/style.rs	11	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/style.rs	13	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	source	crates/vize_glyph/src/style/stabilization.rs	9	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	test/dev	crates/vize_glyph/src/style/stabilization.rs	226	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	test/dev	crates/vize_glyph/src/template.rs	28	s0	S0	stage	vize_s0	preferred	2


### PR DESCRIPTION
Closes #6026

## Summary
- keep plain CSS style blocks raw when they contain nested block comments, avoiding lightningcss comment loss
- preserve top-level comment formatting behavior for safe CSS chunks
- add style and SFC regression coverage for nested, pre-rule, and inline comments

## Verification
- CARGO_BUILD_JOBS=2 cargo test -p vize_glyph test_format_preserves_nested_block_comments_by_leaving_block_raw -- --nocapture
- CARGO_BUILD_JOBS=2 cargo test -p vize_glyph test_format_sfc_plain_style_preserves_nested_comments -- --nocapture
- CARGO_BUILD_JOBS=2 cargo test -p vize_glyph -- --nocapture
- cargo fmt --all
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791692977&installation_model_id=422833&pr_number=6031&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6031&signature=636d0ad6aea970581c1eed3efd4a1912c32c60fc38c8de7c56f6593e00f08b3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved nested and inline comments when formatting plain, scoped CSS style blocks.
  * Prevented formatting from dropping or altering source content containing nested comments.
  * Preserved comment markers within unquoted URLs and correctly handled comments after `@import` URL data.
  * Ensured repeated formatting produces consistent results for affected style blocks.

* **Tests**
  * Added coverage for nested comments, escaped braces, URLs, quoted strings, and incomplete comment blocks.
  * Added regression coverage confirming comment preservation and formatting idempotence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->