### PR TITLE
perf(canon): dedup import invalidation paths

### DIFF
--- a/crates/vize/src/commands/check/imports_package_routes.rs
+++ b/crates/vize/src/commands/check/imports_package_routes.rs
@@ -1,6 +1,19 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, path::PathBuf};
 
 use vize_canon::{PackageResolutionContext, PackageRouteBinding};
+
+/// Byte-order dedup. `PathBuf` equality is bytewise, so this is exact; it only
+/// avoids `PathBuf::cmp`'s component-wise walk over long package-manager paths.
+pub(super) fn dedup_paths_sorted(paths: &mut Vec<PathBuf>) {
+    paths.sort_unstable_by(|left, right| left.as_os_str().cmp(right.as_os_str()));
+    paths.dedup();
+}
+
+fn dedup_paths_merged(paths: &mut Vec<PathBuf>) {
+    let mut seen = vize_s0::FxHashSet::default();
+    paths.retain(|path| seen.insert(path.clone()));
+    paths.sort_unstable_by(|left, right| left.as_os_str().cmp(right.as_os_str()));
+}
 
 pub(super) fn sort_package_route_bindings(bindings: &mut Vec<PackageRouteBinding>) {
     bindings.sort_by(compare_binding_keys);
@@ -24,8 +37,7 @@ pub(super) fn sort_package_route_bindings(bindings: &mut Vec<PackageRouteBinding
     }
     if merged {
         for binding in &mut deduped {
-            binding.invalidation_paths.sort();
-            binding.invalidation_paths.dedup();
+            dedup_paths_merged(&mut binding.invalidation_paths);
         }
     }
     *bindings = deduped;
@@ -65,8 +77,6 @@ fn same_binding_key(left: &PackageRouteBinding, right: &PackageRouteBinding) -> 
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use vize_canon::{PackageResolutionContext, PackageResolutionMode};
 
     use super::*;
@@ -111,5 +121,39 @@ mod tests {
             ]
         );
         assert_eq!(bindings[1].occurrence_mode, PackageResolutionMode::Require);
+    }
+
+    #[test]
+    fn merged_invalidation_paths_are_deduped_once() {
+        let mut bindings = vec![
+            binding(
+                PackageResolutionMode::Import,
+                [
+                    "/workspace/pkg/package.json",
+                    "/workspace/pkg/index.d.ts",
+                    "/workspace/pkg/package.json",
+                ],
+            ),
+            binding(
+                PackageResolutionMode::Import,
+                [
+                    "/workspace/pkg/index.d.ts",
+                    "/workspace/pkg/types.d.ts",
+                    "/workspace/pkg/types.d.ts",
+                ],
+            ),
+        ];
+
+        sort_package_route_bindings(&mut bindings);
+
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(
+            bindings[0].invalidation_paths,
+            vec![
+                PathBuf::from("/workspace/pkg/index.d.ts"),
+                PathBuf::from("/workspace/pkg/package.json"),
+                PathBuf::from("/workspace/pkg/types.d.ts"),
+            ],
+        );
     }
 }

--- a/crates/vize/src/commands/check/imports_registration.rs
+++ b/crates/vize/src/commands/check/imports_registration.rs
@@ -222,8 +222,9 @@ fn source_needs_virtual_registration(
                             binding_route = Some(route);
                         }
                     }
-                    invalidation_paths.sort();
-                    invalidation_paths.dedup();
+                    super::super::imports_package_routes::dedup_paths_sorted(
+                        &mut invalidation_paths,
+                    );
                     if needs_shadow || track_reachability || watchable_negative {
                         discovered_routes.push(vize_canon::PackageRouteBinding {
                             importer_path: file.clone(),

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |          1136 |                   787 |               349 |             158 |     373 |            1009 |      658 |           561 |           700 |
 | Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           569 |
-| Typechecker                |           936 |                   257 |               679 |             416 |     214 |             875 |      691 |           506 |           722 |
+| Typechecker                |           937 |                   258 |               679 |             416 |     214 |             876 |      691 |           506 |           722 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            40 |                    40 |                 0 |               0 |      21 |              42 |       19 |            32 |            69 |
 | LSP                        |           301 |                   301 |                 0 |             115 |      47 |             349 |      114 |           174 |           410 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         936 |             533 |      403 |
+| S0               |         937 |             534 |      403 |
 | old AST/parser   |         167 |              37 |      130 |
 | Croquis analysis |         249 |             127 |      122 |
 | raw OXC          |         214 |             178 |       36 |
@@ -149,7 +149,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 | `crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs:7` | source   | S0 10                                                       |    10 |
 | `crates/vize_canon/src/virtual_ts/scope/context.rs:3`                          | source   | S0 4<br>old AST/parser 2<br>Croquis analysis 3              |     9 |
 
-Additional source/manifest rows are in the TSV: 334 omitted.
+Additional source/manifest rows are in the TSV: 335 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2575,7 +2575,8 @@ typechecker	Typechecker	source	crates/vize/src/commands/check/imports_cache.rs	9
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_generated_tests.rs	3	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_js_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_magic_comments_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_package_routes.rs	80	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_package_routes.rs	13	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_package_routes.rs	90	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/imports_registration.rs	3	s0	S0	stage	vize_s0	preferred	2
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_registration.rs	175	s0	S0	stage	vize_s0	preferred	2
 typechecker	Typechecker	source	crates/vize/src/commands/check/imports_resolution.rs	5	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- dedupe importer invalidation paths through a shared deterministic path sorter
- collapse duplicated merged package-route invalidation paths before sorting
- cover duplicate merge behavior so per-binding path work stays bounded

Refs #6029

## Verification
- CARGO_BUILD_JOBS=2 cargo test -p vize merged_invalidation_paths_are_deduped_once -- --nocapture
- CARGO_BUILD_JOBS=2 cargo test -p vize package_route_bindings_merge_by_importer_specifier_mode_and_context -- --nocapture
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791693789&installation_model_id=422833&pr_number=6032&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6032&signature=3de94b5963aff8829077b803b783aefd050f0313113d10a9c5f003dfcdf8e4bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->