### PR TITLE
feat(ui): add reactive Standard Schema form state

### DIFF
--- a/npm/ui/scripts/check-size.mjs
+++ b/npm/ui/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 196_500],
+  ["index.mjs", 199_000],
   ["alert.mjs", 1_050],
   ["announcer.mjs", 4_100],
   ["aspect-ratio.mjs", 1_500],
@@ -76,7 +76,7 @@ const budgets = new Map([
   ["icon-button.mjs", 2_200],
   ["field.mjs", 6_200],
   ["field-wiring.mjs", 2_700],
-  ["form.mjs", 2_300],
+  ["form.mjs", 4_200],
   ["id.mjs", 2_400],
   ["inert-outside.mjs", 3_350],
   ["interaction-modality.mjs", 3_300],

--- a/npm/ui/src/catalog/family-catalog-foundations.ts
+++ b/npm/ui/src/catalog/family-catalog-foundations.ts
@@ -253,11 +253,16 @@ export const foundationFamilyCatalog = [
     sourceFiles: [
       `${formFamilyRoot}form.ts`,
       `${formFamilyRoot}form-runtime.ts`,
+      `${formFamilyRoot}form-state.ts`,
+      `${formFamilyRoot}form-state-types.ts`,
       `${formFamilyRoot}form-types.ts`,
     ],
     behaviorContract: `${formFamilyRoot}form.behavior.md`,
-    tests: [`${formFamilyRoot}form.test.ts`],
-    typeTests: [`${formFamilyRoot}form.types.test-d.ts`],
+    tests: [`${formFamilyRoot}form.test.ts`, `${formFamilyRoot}form-state.test.ts`],
+    typeTests: [
+      `${formFamilyRoot}form.types.test-d.ts`,
+      `${formFamilyRoot}form-state.types.test-d.ts`,
+    ],
     qualityGates: stableQualityGates,
     bundleBudget: {
       exportName: "validateStandardSchema",

--- a/npm/ui/src/families/form/form/form-state-types.ts
+++ b/npm/ui/src/families/form/form/form-state-types.ts
@@ -1,0 +1,212 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from "vue";
+
+import type { ErrorSummaryField } from "../error-summary/error-summary-types.ts";
+import type {
+  FormErrorSummaryFieldOptions,
+  FormFieldError,
+  FormValidationResult,
+  FormValidationSuccess,
+  StandardSchemaV1,
+  StandardSchemaValidationOptions,
+} from "./form-types.ts";
+
+/** Element-like focus target registered for invalid-field focus movement. */
+export interface FormFocusableElement {
+  /** Move browser focus to the control. */
+  focus(options?: FocusOptions): void;
+}
+
+/** One tracked field's aggregate form state. */
+export interface FormFieldState {
+  /** Normalized HTML form field name. */
+  readonly name: string;
+
+  /** Whether the field value has been changed by the consumer. */
+  readonly isDirty: boolean;
+
+  /** Whether the field has received focus or equivalent visitation. */
+  readonly isVisited: boolean;
+
+  /** Whether the field has been blurred or equivalent confirmation. */
+  readonly isTouched: boolean;
+
+  /** Whether this field currently has at least one normalized error. */
+  readonly isInvalid: boolean;
+
+  /** Current errors for this field only. */
+  readonly errors: readonly FormFieldError[];
+
+  /** First current error for this field. */
+  readonly firstError: FormFieldError | undefined;
+
+  /** First current error message for this field. */
+  readonly errorMessage: string | undefined;
+}
+
+/** Options accepted by {@link normalizeNativeConstraintErrors}. */
+export interface NativeConstraintErrorOptions {
+  /**
+   * Resolve a field name for one invalid native form control.
+   *
+   * @default the control's `name` attribute
+   */
+  readonly nameForControl?: (control: Element) => string | null | undefined;
+
+  /**
+   * Resolve the message for one invalid native form control.
+   *
+   * @default the control's `validationMessage`, or `"Invalid value"`
+   */
+  readonly messageForControl?: (control: Element) => string | undefined;
+}
+
+/** Options accepted by {@link useFormState}. */
+export interface FormStateOptions<
+  Input = unknown,
+  Output = Input,
+> extends FormErrorSummaryFieldOptions {
+  /**
+   * Standard Schema used by `validate` and `submit`.
+   *
+   * @default undefined
+   */
+  readonly schema?: StandardSchemaV1<Input, Output>;
+
+  /**
+   * Initial normalized errors.
+   *
+   * @default []
+   */
+  readonly initialErrors?: readonly FormFieldError[];
+
+  /**
+   * Submit callback invoked only for the latest valid submission.
+   *
+   * @default undefined
+   */
+  readonly onSubmit?: (value: Output, result: FormValidationSuccess<Output>) => unknown;
+
+  /**
+   * Move focus to the first registered invalid field after an invalid submit.
+   *
+   * @default true
+   */
+  readonly focusFirstInvalidOnSubmit?: boolean;
+}
+
+/** Per-submit options layered on top of Standard Schema normalization. */
+export interface FormSubmitOptions<Output> extends StandardSchemaValidationOptions {
+  /**
+   * Submit callback for this call. Overrides the controller default.
+   *
+   * @default controller `onSubmit`
+   */
+  readonly onSubmit?: (value: Output, result: FormValidationSuccess<Output>) => unknown;
+
+  /**
+   * Move focus to the first registered invalid field after this invalid submit.
+   *
+   * @default controller `focusFirstInvalidOnSubmit`
+   */
+  readonly focusFirstInvalid?: boolean;
+}
+
+/** Options accepted by {@link FormStateController.reset}. */
+export interface FormStateResetOptions {
+  /**
+   * Errors to install after reset.
+   *
+   * @default []
+   */
+  readonly errors?: readonly FormFieldError[];
+
+  /**
+   * Field names that should remain dirty after reset.
+   *
+   * @default []
+   */
+  readonly dirtyFields?: readonly string[];
+
+  /**
+   * Field names that should remain touched after reset.
+   *
+   * @default []
+   */
+  readonly touchedFields?: readonly string[];
+
+  /**
+   * Field names that should remain visited after reset.
+   *
+   * @default []
+   */
+  readonly visitedFields?: readonly string[];
+}
+
+/** Reactive controller for Standard Schema form state and submission. */
+export interface FormStateController<Input = unknown, Output = Input> {
+  /** Current normalized validation and server errors. */
+  readonly errors: Readonly<Ref<readonly FormFieldError[]>>;
+
+  /** Error-summary fields derived from current errors. */
+  readonly summaryFields: ComputedRef<readonly ErrorSummaryField[]>;
+
+  /** Whether at least one current error exists. */
+  readonly hasErrors: ComputedRef<boolean>;
+
+  /** Whether any field has been marked dirty. */
+  readonly isDirty: ComputedRef<boolean>;
+
+  /** Whether any field has been marked touched. */
+  readonly isTouched: ComputedRef<boolean>;
+
+  /** Whether any field has been marked visited. */
+  readonly isVisited: ComputedRef<boolean>;
+
+  /** Whether at least one schema validation is currently pending. */
+  readonly isValidating: ComputedRef<boolean>;
+
+  /** Whether at least one submission is currently pending. */
+  readonly isSubmitting: ComputedRef<boolean>;
+
+  /** Number of submit attempts made through this controller. */
+  readonly submitCount: Readonly<Ref<number>>;
+
+  /** Aggregate state for one field name. */
+  fieldState(name: MaybeRefOrGetter<string>): ComputedRef<FormFieldState>;
+
+  /** Register a focus target for first-invalid focus movement. */
+  registerField(name: string, element: FormFocusableElement | null | undefined): () => void;
+
+  /** Mark or unmark one field as dirty. */
+  markFieldDirty(name: string, dirty?: boolean): void;
+
+  /** Mark or unmark one field as touched. */
+  markFieldTouched(name: string, touched?: boolean): void;
+
+  /** Mark or unmark one field as visited. */
+  markFieldVisited(name: string, visited?: boolean): void;
+
+  /** Replace current errors with normalized validation or server errors. */
+  setErrors(errors: readonly FormFieldError[]): void;
+
+  /** Replace current errors with server-returned normalized field errors. */
+  setServerErrors(errors: readonly FormFieldError[]): void;
+
+  /** Clear current errors. */
+  clearErrors(): void;
+
+  /** Reset errors and tracked field interaction state. */
+  reset(options?: FormStateResetOptions): void;
+
+  /** Validate with the configured Standard Schema, discarding stale side effects. */
+  validate(
+    value: Input,
+    options?: StandardSchemaValidationOptions,
+  ): Promise<FormValidationResult<Output>>;
+
+  /** Validate, submit the latest valid result, and focus the first invalid field. */
+  submit(value: Input, options?: FormSubmitOptions<Output>): Promise<FormValidationResult<Output>>;
+
+  /** Focus the first registered field with a current error. */
+  focusFirstInvalid(options?: FocusOptions): boolean;
+}

--- a/npm/ui/src/families/form/form/form-state.test.ts
+++ b/npm/ui/src/families/form/form/form-state.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { effectScope, nextTick } from "vue";
+
+import {
+  normalizeNativeConstraintErrors,
+  useFormState,
+  type FormFieldError,
+  type StandardSchemaV1,
+} from "./form.ts";
+
+function schema<Input, Output>(
+  validate: StandardSchemaV1<Input, Output>["~standard"]["validate"],
+): StandardSchemaV1<Input, Output> {
+  return {
+    "~standard": {
+      validate,
+      vendor: "test",
+      version: 1,
+    },
+  };
+}
+
+test("normalizes native constraint validation failures", () => {
+  const form = document.createElement("form");
+  const unnamed = document.createElement("input");
+  const email = document.createElement("input");
+  email.name = "account.email";
+  email.setCustomValidity("Use a work email");
+  unnamed.setCustomValidity("Ignored");
+  form.append(unnamed, email);
+  document.body.append(form);
+
+  const errors = normalizeNativeConstraintErrors(form);
+  assert.deepEqual(errors, [
+    { message: "Use a work email", name: "account.email", path: ["account.email"] },
+  ]);
+
+  const renamed = normalizeNativeConstraintErrors(form, {
+    messageForControl: () => "Server-compatible email required",
+    nameForControl: (control) => {
+      const name = control.getAttribute("name");
+      return name === null ? null : `native:${name}`;
+    },
+  });
+  assert.deepEqual(renamed, [
+    {
+      message: "Server-compatible email required",
+      name: "native:account.email",
+      path: ["native:account.email"],
+    },
+  ]);
+  form.remove();
+});
+
+test("tracks field state and focuses the first registered invalid field", async () => {
+  const controller = useFormState();
+  const email = document.createElement("input");
+  const password = document.createElement("input");
+  email.name = "email";
+  password.name = "password";
+  document.body.append(email, password);
+  const unregisterEmail = controller.registerField("email", email);
+  controller.registerField("password", password);
+
+  const emailState = controller.fieldState("email");
+  assert.equal(emailState.value.isDirty, false);
+  assert.equal(controller.isDirty.value, false);
+
+  controller.markFieldVisited("email");
+  controller.markFieldDirty("email");
+  controller.markFieldTouched("email");
+  controller.setServerErrors([
+    { message: "Enter a password", name: "password", path: ["password"] },
+    { message: "Enter an email", name: "email", path: ["email"] },
+  ]);
+  await nextTick();
+
+  assert.equal(emailState.value.isDirty, true);
+  assert.equal(emailState.value.isTouched, true);
+  assert.equal(emailState.value.isVisited, true);
+  assert.equal(emailState.value.isInvalid, true);
+  assert.equal(emailState.value.errorMessage, "Enter an email");
+  assert.equal(controller.isDirty.value, true);
+  assert.equal(controller.isTouched.value, true);
+  assert.equal(controller.isVisited.value, true);
+  assert.equal(controller.focusFirstInvalid(), true);
+  assert.equal(document.activeElement, password);
+
+  unregisterEmail();
+  controller.reset();
+  assert.equal(controller.hasErrors.value, false);
+  assert.equal(controller.isDirty.value, false);
+  email.remove();
+  password.remove();
+});
+
+test("discards stale async validation results", async () => {
+  type Input = { readonly email: string };
+  type Output = Input & { readonly normalized: true };
+  const resolvers: Array<(result: StandardSchemaV1.Result<Output>) => void> = [];
+  const controller = useFormState({
+    schema: schema<Input, Output>(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    ),
+  });
+
+  const slow = controller.validate({ email: "slow@example.com" });
+  const fast = controller.validate({ email: "fast@example.com" });
+  assert.equal(controller.isValidating.value, true);
+  resolvers[1]?.({ value: { email: "fast@example.com", normalized: true } });
+  const fastResult = await fast;
+  assert.equal(fastResult.valid, true);
+  assert.equal(controller.hasErrors.value, false);
+  assert.equal(controller.isValidating.value, true);
+
+  resolvers[0]?.({
+    issues: [{ message: "Too slow", path: ["email"] }],
+  });
+  const slowResult = await slow;
+  assert.equal(slowResult.valid, false);
+  assert.deepEqual(controller.errors.value, []);
+  assert.equal(controller.isValidating.value, false);
+});
+
+test("copies stored error paths before exposing field state", () => {
+  const path = ["email"];
+  const controller = useFormState({
+    initialErrors: [{ message: "Bad email", name: "email", path }],
+  });
+  const emailState = controller.fieldState("email");
+
+  path.push("mutated");
+  assert.deepEqual(controller.errors.value, [
+    { message: "Bad email", name: "email", path: ["email"] },
+  ]);
+  assert.deepEqual(emailState.value.errors, [
+    { message: "Bad email", name: "email", path: ["email"] },
+  ]);
+  assert.equal(Object.isFrozen(controller.errors.value[0]?.path), true);
+});
+
+test("reset invalidates in-flight submit results", async () => {
+  type Input = { readonly email: string };
+  type Output = Input & { readonly normalized: true };
+  const submitted: Output[] = [];
+  let resolveSubmit: ((result: StandardSchemaV1.Result<Output>) => void) | undefined;
+  const controller = useFormState<Input, Output>({
+    onSubmit: (value) => submitted.push(value),
+    schema: schema(
+      () =>
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    ),
+  });
+
+  const pendingSubmit = controller.submit({ email: "me@example.com" });
+  controller.reset();
+  resolveSubmit?.({ value: { email: "me@example.com", normalized: true } });
+
+  const result = await pendingSubmit;
+  assert.equal(result.valid, true);
+  assert.deepEqual(submitted, []);
+  assert.deepEqual(controller.errors.value, []);
+  assert.equal(controller.isSubmitting.value, false);
+});
+
+test("submits only the latest valid result", async () => {
+  type Input = { readonly email: string };
+  type Output = Input & { readonly normalized: true };
+  const submitted: Output[] = [];
+  const email = document.createElement("input");
+  email.name = "email";
+  document.body.append(email);
+  const controller = useFormState<Input, Output>({
+    onSubmit: (value) => submitted.push(value),
+    schema: schema((value) => {
+      const input = value as Input;
+      return input.email.includes("@")
+        ? { value: { email: input.email.toLowerCase(), normalized: true } }
+        : { issues: [{ message: "Enter an email", path: ["email"] }] };
+    }),
+  });
+  controller.registerField("email", email);
+
+  const invalid = await controller.submit({ email: "bad" });
+  assert.equal(invalid.valid, false);
+  assert.equal(document.activeElement, email);
+  assert.deepEqual(submitted, []);
+  assert.equal(controller.submitCount.value, 1);
+
+  const valid = await controller.submit({ email: "ME@EXAMPLE.COM" });
+  assert.equal(valid.valid, true);
+  assert.deepEqual(submitted, [{ email: "me@example.com", normalized: true }]);
+  assert.equal(controller.isSubmitting.value, false);
+  email.remove();
+});
+
+test("rejects malformed state and native constraint inputs", async () => {
+  assert.throws(() => useFormState(null as never), /VIZE_UI_FORM_STATE/);
+  assert.throws(
+    () => normalizeNativeConstraintErrors(document.createElement("div") as never),
+    /VIZE_UI_FORM_CONSTRAINT/,
+  );
+
+  const controller = useFormState({
+    initialErrors: [{ message: "Bad", name: "email", path: ["email"] }],
+  });
+  assert.throws(
+    () => controller.registerField("", document.createElement("input")),
+    /VIZE_UI_FORM_STATE/,
+  );
+  assert.throws(
+    () => controller.setErrors([{ message: "Bad", name: "email", path: "email" }] as never),
+    /VIZE_UI_FORM_STATE/,
+  );
+  await assert.rejects(() => controller.validate("value"), /VIZE_UI_FORM_STATE/);
+});
+
+test("keeps server errors in the shared summary pipeline", () => {
+  const serverErrors: readonly FormFieldError[] = [
+    { message: "Email already exists", name: "email", path: ["email"] },
+    { message: "Try another email", name: "email", path: ["email"] },
+  ];
+  const scope = effectScope();
+  const controller = scope.run(() =>
+    useFormState({
+      initialErrors: serverErrors,
+      labelForName: (name) => (name === "email" ? "Email" : undefined),
+    }),
+  );
+  assert.ok(controller);
+  assert.deepEqual(controller.summaryFields.value, [
+    { id: "email", label: "Email", message: "Email already exists" },
+  ]);
+  controller.clearErrors();
+  assert.deepEqual(controller.summaryFields.value, []);
+  scope.stop();
+});

--- a/npm/ui/src/families/form/form/form-state.ts
+++ b/npm/ui/src/families/form/form/form-state.ts
@@ -1,0 +1,315 @@
+import { computed, ref, toValue, type MaybeRefOrGetter, type Ref } from "vue";
+
+import { createFormErrorSummaryFields, validateStandardSchema } from "./form-runtime.ts";
+import type {
+  FormFieldError,
+  FormValidationResult,
+  StandardSchemaV1,
+  StandardSchemaValidationOptions,
+} from "./form-types.ts";
+import type {
+  FormFieldState,
+  FormFocusableElement,
+  FormStateController,
+  FormStateOptions,
+  FormStateResetOptions,
+  FormSubmitOptions,
+  NativeConstraintErrorOptions,
+} from "./form-state-types.ts";
+
+const formStateDiagnostic = "VIZE_UI_FORM_STATE";
+const nativeConstraintDiagnostic = "VIZE_UI_FORM_CONSTRAINT";
+
+function assertOptions(value: unknown, name: string): void {
+  if (typeof value !== "object" || value === null) {
+    throw new TypeError(`${formStateDiagnostic}: ${name} must be an object`);
+  }
+}
+
+function readFieldName(value: unknown, name = "name"): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${formStateDiagnostic}: ${name} must resolve to a non-empty string`);
+  }
+  return value;
+}
+
+function readErrors(errors: readonly FormFieldError[] | undefined): readonly FormFieldError[] {
+  if (errors === undefined) return Object.freeze([]);
+  if (!Array.isArray(errors)) {
+    throw new TypeError(`${formStateDiagnostic}: errors must be an array`);
+  }
+  return Object.freeze(
+    errors.map((error) => {
+      if (typeof error?.name !== "string" || typeof error.message !== "string") {
+        throw new TypeError(`${formStateDiagnostic}: every error needs name and message strings`);
+      }
+      if (!Array.isArray(error.path)) {
+        throw new TypeError(`${formStateDiagnostic}: every error needs a path array`);
+      }
+      return Object.freeze({
+        message: error.message,
+        name: error.name,
+        path: Object.freeze([...error.path]),
+      });
+    }),
+  );
+}
+
+function readNameSet(values: readonly string[] | undefined): ReadonlySet<string> {
+  if (values === undefined) return Object.freeze(new Set<string>());
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${formStateDiagnostic}: field lists must be arrays`);
+  }
+  const names = new Set<string>();
+  for (const value of values) names.add(readFieldName(value, "field name"));
+  return Object.freeze(names);
+}
+
+function updateNameSet(target: Ref<ReadonlySet<string>>, name: string, active: boolean): void {
+  const fieldName = readFieldName(name, "field name");
+  const next = new Set(target.value);
+  if (active) next.add(fieldName);
+  else next.delete(fieldName);
+  target.value = Object.freeze(next);
+}
+
+function readSchema<Input, Output>(
+  schema: StandardSchemaV1<Input, Output> | undefined,
+): StandardSchemaV1<Input, Output> {
+  if (schema === undefined) {
+    throw new TypeError(`${formStateDiagnostic}: schema is required to validate`);
+  }
+  return schema;
+}
+
+function controlName(control: Element, options: NativeConstraintErrorOptions): string | undefined {
+  const resolved = options.nameForControl?.(control) ?? control.getAttribute("name") ?? undefined;
+  if (resolved === null || resolved === undefined || resolved === "") return undefined;
+  if (typeof resolved !== "string") {
+    throw new TypeError(`${nativeConstraintDiagnostic}: control names must be strings`);
+  }
+  return resolved;
+}
+
+function controlMessage(control: Element, options: NativeConstraintErrorOptions): string {
+  const resolved =
+    options.messageForControl?.(control) ??
+    ("validationMessage" in control && typeof control.validationMessage === "string"
+      ? control.validationMessage
+      : undefined);
+  if (resolved === undefined || resolved.length === 0) return "Invalid value";
+  if (typeof resolved !== "string") {
+    throw new TypeError(`${nativeConstraintDiagnostic}: control messages must be strings`);
+  }
+  return resolved;
+}
+
+function isInvalidNativeControl(control: Element): boolean {
+  if (!("checkValidity" in control) || typeof control.checkValidity !== "function") return false;
+  if ("willValidate" in control && control.willValidate === false) return false;
+  return !control.checkValidity();
+}
+
+/** Convert native constraint-validation failures into normalized form errors. */
+export function normalizeNativeConstraintErrors(
+  form: HTMLFormElement,
+  options: NativeConstraintErrorOptions = {},
+): readonly FormFieldError[] {
+  if (!(form instanceof HTMLFormElement)) {
+    throw new TypeError(`${nativeConstraintDiagnostic}: form must be an HTMLFormElement`);
+  }
+  assertOptions(options, "options");
+
+  const errors: FormFieldError[] = [];
+  for (const control of Array.from(form.elements)) {
+    if (!(control instanceof Element) || !isInvalidNativeControl(control)) continue;
+    const name = controlName(control, options);
+    if (name === undefined) continue;
+    errors.push(
+      Object.freeze({
+        message: controlMessage(control, options),
+        name,
+        path: Object.freeze([name]),
+      }),
+    );
+  }
+  return Object.freeze(errors);
+}
+
+/** Create reactive form state around Standard Schema validation and submission. */
+export function useFormState<Input, Output = Input>(
+  options: FormStateOptions<Input, Output> = {},
+): FormStateController<Input, Output> {
+  assertOptions(options, "options");
+
+  const errors = ref(readErrors(options.initialErrors)) as Ref<readonly FormFieldError[]>;
+  const dirtyFields = ref(readNameSet(undefined)) as Ref<ReadonlySet<string>>;
+  const touchedFields = ref(readNameSet(undefined)) as Ref<ReadonlySet<string>>;
+  const visitedFields = ref(readNameSet(undefined)) as Ref<ReadonlySet<string>>;
+  const activeValidations = ref(0);
+  const activeSubmits = ref(0);
+  const validationSequence = ref(0);
+  const submitSequence = ref(0);
+  const submitCount = ref(0);
+  const registeredFields = new Map<string, FormFocusableElement>();
+
+  const summaryFields = computed(() =>
+    createFormErrorSummaryFields(errors.value, {
+      ...(options.idForName === undefined ? {} : { idForName: options.idForName }),
+      ...(options.labelForName === undefined ? {} : { labelForName: options.labelForName }),
+      ...(options.rootId === undefined ? {} : { rootId: options.rootId }),
+      ...(options.rootLabel === undefined ? {} : { rootLabel: options.rootLabel }),
+    }),
+  );
+
+  const hasErrors = computed(() => errors.value.length > 0);
+  const isDirty = computed(() => dirtyFields.value.size > 0);
+  const isTouched = computed(() => touchedFields.value.size > 0);
+  const isVisited = computed(() => visitedFields.value.size > 0);
+  const isValidating = computed(() => activeValidations.value > 0);
+  const isSubmitting = computed(() => activeSubmits.value > 0);
+
+  function setErrors(nextErrors: readonly FormFieldError[]): void {
+    errors.value = readErrors(nextErrors);
+  }
+
+  function reset(resetOptions: FormStateResetOptions = {}): void {
+    assertOptions(resetOptions, "reset options");
+    validationSequence.value += 1;
+    submitSequence.value += 1;
+    errors.value = readErrors(resetOptions.errors);
+    dirtyFields.value = readNameSet(resetOptions.dirtyFields);
+    touchedFields.value = readNameSet(resetOptions.touchedFields);
+    visitedFields.value = readNameSet(resetOptions.visitedFields);
+  }
+
+  async function validate(
+    value: Input,
+    validationOptions: StandardSchemaValidationOptions = {},
+  ): Promise<FormValidationResult<Output>> {
+    const sequence = validationSequence.value + 1;
+    validationSequence.value = sequence;
+    activeValidations.value += 1;
+    try {
+      const result = await validateStandardSchema(
+        readSchema(options.schema),
+        value,
+        validationOptions,
+      );
+      if (sequence === validationSequence.value) setErrors(result.errors);
+      return result;
+    } finally {
+      activeValidations.value = Math.max(0, activeValidations.value - 1);
+    }
+  }
+
+  async function submit(
+    value: Input,
+    submitOptions: FormSubmitOptions<Output> = {},
+  ): Promise<FormValidationResult<Output>> {
+    assertOptions(submitOptions, "submit options");
+    const sequence = submitSequence.value + 1;
+    submitSequence.value = sequence;
+    submitCount.value += 1;
+    activeSubmits.value += 1;
+    try {
+      const result = await validate(value, submitOptions);
+      if (sequence !== submitSequence.value) return result;
+      if (!result.valid) {
+        if (submitOptions.focusFirstInvalid ?? options.focusFirstInvalidOnSubmit ?? true) {
+          focusFirstInvalid();
+        }
+        return result;
+      }
+      const onSubmit = submitOptions.onSubmit ?? options.onSubmit;
+      if (onSubmit !== undefined) await onSubmit(result.value, result);
+      return result;
+    } finally {
+      activeSubmits.value = Math.max(0, activeSubmits.value - 1);
+    }
+  }
+
+  function fieldState(
+    nameInput: MaybeRefOrGetter<string>,
+  ): ReturnType<FormStateController["fieldState"]> {
+    return computed<FormFieldState>(() => {
+      const name = readFieldName(toValue(nameInput));
+      const fieldErrors = Object.freeze(errors.value.filter((error) => error.name === name));
+      const firstError = fieldErrors[0];
+      return Object.freeze({
+        errorMessage: firstError?.message,
+        errors: fieldErrors,
+        firstError,
+        isDirty: dirtyFields.value.has(name),
+        isInvalid: fieldErrors.length > 0,
+        isTouched: touchedFields.value.has(name),
+        isVisited: visitedFields.value.has(name),
+        name,
+      });
+    });
+  }
+
+  function registerField(
+    name: string,
+    element: FormFocusableElement | null | undefined,
+  ): () => void {
+    const fieldName = readFieldName(name, "field name");
+    if (element === null || element === undefined) {
+      registeredFields.delete(fieldName);
+      return () => {};
+    }
+    if (typeof element.focus !== "function") {
+      throw new TypeError(`${formStateDiagnostic}: registered fields must be focusable`);
+    }
+    registeredFields.set(fieldName, element);
+    return () => {
+      if (registeredFields.get(fieldName) === element) registeredFields.delete(fieldName);
+    };
+  }
+
+  function focusFirstInvalid(options?: FocusOptions): boolean {
+    for (const error of errors.value) {
+      const target = registeredFields.get(error.name);
+      if (target === undefined) continue;
+      target.focus(options);
+      return true;
+    }
+    return false;
+  }
+
+  function markFieldDirty(name: string, dirty = true): void {
+    updateNameSet(dirtyFields, name, dirty);
+  }
+
+  function markFieldTouched(name: string, touched = true): void {
+    updateNameSet(touchedFields, name, touched);
+  }
+
+  function markFieldVisited(name: string, visited = true): void {
+    updateNameSet(visitedFields, name, visited);
+  }
+
+  return Object.freeze({
+    clearErrors: () => setErrors([]),
+    errors,
+    fieldState,
+    focusFirstInvalid,
+    hasErrors,
+    isDirty,
+    isSubmitting,
+    isTouched,
+    isValidating,
+    isVisited,
+    markFieldDirty,
+    markFieldTouched,
+    markFieldVisited,
+    registerField,
+    reset,
+    setErrors,
+    setServerErrors: setErrors,
+    submit,
+    submitCount,
+    summaryFields,
+    validate,
+  });
+}

--- a/npm/ui/src/families/form/form/form-state.types.test-d.ts
+++ b/npm/ui/src/families/form/form/form-state.types.test-d.ts
@@ -1,0 +1,70 @@
+/** Compile-only assertions for reactive form state. */
+
+import type { ComputedRef, Ref } from "vue";
+
+import {
+  normalizeNativeConstraintErrors,
+  useFormState,
+  type FormFieldState,
+  type FormStateController,
+  type FormValidationResult,
+  type StandardSchemaV1,
+} from "./form.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+interface SignInInput {
+  readonly email: string;
+}
+
+interface SignInOutput extends SignInInput {
+  readonly normalized: true;
+}
+
+declare const schema: StandardSchemaV1<SignInInput, SignInOutput>;
+
+export const form = useFormState({
+  initialErrors: [{ message: "Bad", name: "email", path: ["email"] }],
+  schema,
+});
+export const field = form.fieldState("email");
+export const validation = form.validate({ email: "me@example.com" });
+export const submission = form.submit({ email: "me@example.com" });
+export const nativeErrors = normalizeNativeConstraintErrors(document.createElement("form"));
+
+type _ControllerInfersSchema = Expect<
+  Equal<typeof form, FormStateController<SignInInput, SignInOutput>>
+>;
+type _ErrorsAreReadonlyRef = Expect<
+  Equal<FormStateController["errors"], Readonly<Ref<readonly import("./form.ts").FormFieldError[]>>>
+>;
+type _FieldStateIsComputed = Expect<Equal<typeof field, ComputedRef<FormFieldState>>>;
+type _ValidationKeepsOutput = Expect<
+  Equal<typeof validation, Promise<FormValidationResult<SignInOutput>>>
+>;
+type _SubmissionKeepsOutput = Expect<
+  Equal<typeof submission, Promise<FormValidationResult<SignInOutput>>>
+>;
+
+form.markFieldDirty("email");
+form.markFieldTouched("email", false);
+form.markFieldVisited("email");
+form.setServerErrors(nativeErrors);
+form.reset({ dirtyFields: ["email"], touchedFields: [], visitedFields: [] });
+
+// @ts-expect-error schema input is enforced when validating.
+void form.validate({ email: 1 });
+// @ts-expect-error schema input is enforced when submitting.
+void form.submit({ email: 1 });
+// @ts-expect-error field names must resolve to strings.
+form.fieldState(1);
+// @ts-expect-error reset field lists must be string arrays.
+form.reset({ dirtyFields: [1] });
+// @ts-expect-error the error ref is readonly to consumers.
+form.errors.value = [];
+// @ts-expect-error field state is readonly to consumers.
+field.value.isDirty = false;

--- a/npm/ui/src/families/form/form/form.behavior.md
+++ b/npm/ui/src/families/form/form/form.behavior.md
@@ -15,3 +15,8 @@ Normative state x input -> outcome table for the Standard Schema form foundation
 | F6  | valid        | field receives a matching error      | `useFormField` supplies an invalid flag for field wiring      | `wires field invalid state from normalized errors`                  |
 | F7  | invalid      | field errors feed summary composable | `useFormErrorSummary` exposes existing error-summary fields   | `feeds normalized errors into an error summary controller`          |
 | F8  | public types | mismatched schema input or mutation  | compilation rejects misuse                                    | `src/families/form/form/form.types.test-d.ts`                       |
+| F9  | native form  | constraint-invalid controls          | errors normalize through the same field and summary pipeline  | `normalizes native constraint validation failures`                  |
+| F10 | editing      | field visit, change, and blur events | dirty, visited, and touched state are tracked per field       | `tracks field state and focuses the first registered invalid field` |
+| F11 | invalid      | submitted form has registered fields | focus moves to the first invalid field in current error order | `tracks field state and focuses the first registered invalid field` |
+| F12 | validating   | a slower validation finishes last    | stale results return to their caller but cannot replace state | `discards stale async validation results`                           |
+| F13 | submitting   | latest validation succeeds           | `onSubmit` runs once for the latest valid result              | `submits only the latest valid result`                              |

--- a/npm/ui/src/families/form/form/form.ts
+++ b/npm/ui/src/families/form/form/form.ts
@@ -7,6 +7,7 @@ export {
   useFormField,
   validateStandardSchema,
 } from "./form-runtime.ts";
+export { normalizeNativeConstraintErrors, useFormState } from "./form-state.ts";
 export type {
   FormErrorSummaryController,
   FormErrorSummaryFieldOptions,
@@ -22,3 +23,12 @@ export type {
   StandardSchemaV1,
   StandardSchemaValidationOptions,
 } from "./form-types.ts";
+export type {
+  FormFieldState,
+  FormFocusableElement,
+  FormStateController,
+  FormStateOptions,
+  FormStateResetOptions,
+  FormSubmitOptions,
+  NativeConstraintErrorOptions,
+} from "./form-state-types.ts";


### PR DESCRIPTION
## Summary
- add a reactive form state controller for Standard Schema validation, submission, dirtiness, touched/visited state, and invalid-field focus
- normalize native constraint validation into structured form errors
- document the new form-state rows in the form behavior matrix and catalog metadata

Refs #4897

## Tests
- vp -C npm/ui test run src/families/form/form/form-state.test.ts src/families/form/form/form.test.ts
- vp -C npm/ui check src/families/form/form/form-state.ts src/families/form/form/form-state-types.ts src/families/form/form/form-state.test.ts src/families/form/form/form-state.types.test-d.ts src/families/form/form/form.ts src/families/form/form/form.behavior.md src/catalog/family-catalog-foundations.ts
- vp -C npm/ui exec vue-tsc --noEmit -p tsconfig.typecheck.json
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --max-lines 350 --limit 5 --base-ref origin/main

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791696861&installation_model_id=422833&pr_number=6033&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6033&signature=56026816db2a911e7aeb0238dd8af9aaafb7832b29e8a8d2f6f62388901df221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reactive form-state management with validation, submission, reset, error handling, and field interaction tracking.
  * Added native browser constraint-error normalization.
  * Added first-invalid-field focus behavior during submission.
  * Exposed comprehensive public types for form-state controllers and options.

* **Documentation**
  * Documented form validation, field-state tracking, focus behavior, and asynchronous submission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->