### PR TITLE
fix(release): keep s1 to s2 publish features valid

### DIFF
--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -24,7 +24,7 @@ metadata.vize.stability = "experimental"
 # Arms the corpus-runnable TS-20 lane (`tests/davinci_lowering_corpus.rs`),
 # the P1-6/P1-7 differential-lane shape: committed battery with pinned
 # counts, plus `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>` widening.
-davinci-differential = ["typescript", "vize_atelier_dom/davinci-differential"]
+davinci-differential = ["typescript"]
 
 # The `is_ts` lane erases types by running oxc's transformer, whose
 # `Transformer::new` takes a `&std::path::Path` — so it needs `std`. It stays
@@ -58,7 +58,7 @@ insta = { workspace = true }
 toml = { workspace = true }
 vize_atelier_core = { workspace = true }
 vize_atelier_sfc = { workspace = true }
-vize_atelier_dom = { workspace = true }
+vize_atelier_dom = { workspace = true, features = ["davinci-differential"] }
 vize_croquis = { workspace = true }
 
 [[bench]]


### PR DESCRIPTION
## Summary
- keep the publishable vize_s1_to_s2 feature graph free of dev-dependency feature references
- enable the DOM differential oracle through the test-only dev-dependency instead

## Verification
- cargo fmt --all --check
- git diff --check
- CARGO_BUILD_JOBS=2 cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- release recovery: vize_s1_to_s2 v0.407.0 published and resolved from crates.io with the same manifest adjustment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791700153&installation_model_id=422833&pr_number=6034&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6034&signature=f676d4909f22f385f7d1efd83014272268b4fca3f2dbd6e8d0714e42f9f9f477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->