### PR TITLE
fix(ci): prefer HTTPS Ubuntu archives

### DIFF
--- a/.github/actions/setup-ubuntu-archive/action.yml
+++ b/.github/actions/setup-ubuntu-archive/action.yml
@@ -4,17 +4,28 @@ description: Avoid unhealthy Blacksmith mirror-list entries before apt-based set
 runs:
   using: composite
   steps:
-    - name: Use the canonical Ubuntu archive on Blacksmith
+    - name: Use HTTPS Ubuntu archives on Blacksmith
       shell: bash
       run: |
         set -euo pipefail
-        mirror_list=/etc/apt/blacksmith-ubuntu-mirrors.txt
-        if [[ ! -f "$mirror_list" ]]; then
-          exit 0
-        fi
-        printf '%s\n' 'http://archive.ubuntu.com/ubuntu' | sudo tee "$mirror_list" >/dev/null
         sudo tee /etc/apt/apt.conf.d/80-vize-retry-downloads >/dev/null <<'APT'
         Acquire::Retries "5";
         Acquire::http::Timeout "30";
         Acquire::https::Timeout "30";
         APT
+
+        mirror_list=/etc/apt/blacksmith-ubuntu-mirrors.txt
+        if [[ -f "$mirror_list" ]]; then
+          printf '%s\n' 'https://archive.ubuntu.com/ubuntu' | sudo tee "$mirror_list" >/dev/null
+        fi
+
+        apt_source_files=()
+        for candidate in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+          [[ -f "$candidate" ]] && apt_source_files+=("$candidate")
+        done
+        if (( ${#apt_source_files[@]} > 0 )); then
+          sudo sed -i \
+            -e 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+            -e 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' \
+            "${apt_source_files[@]}"
+        fi

--- a/tests/tooling/github-workflows-setup.test.ts
+++ b/tests/tooling/github-workflows-setup.test.ts
@@ -12,7 +12,8 @@ type WorkflowJob = {
 test("apt-based CI setup pins Blacksmith to the canonical Ubuntu archive", () => {
   const action = readRepoFile(".github", "actions", "setup-ubuntu-archive", "action.yml");
   assert.match(action, /\/etc\/apt\/blacksmith-ubuntu-mirrors\.txt/);
-  assert.match(action, /http:\/\/archive\.ubuntu\.com\/ubuntu/);
+  assert.match(action, /https:\/\/archive\.ubuntu\.com\/ubuntu/);
+  assert.match(action, /https:\/\/security\.ubuntu\.com\/ubuntu/);
   assert.match(action, /Acquire::Retries "5";/);
   assert.match(action, /Acquire::http::Timeout "30";/);
   assert.match(action, /Acquire::https::Timeout "30";/);


### PR DESCRIPTION
## Summary
- switch the shared Ubuntu archive stabilization action to HTTPS archive URLs
- rewrite archive and security apt sources before apt-backed setup steps run
- keep existing retry and timeout apt settings covered by workflow tests

## Tests
- node --test tests/tooling/github-workflows-setup.test.ts tests/tooling/editor-real-server-e2e.test.ts tests/tooling/release-tag-rollback.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791708635&installation_model_id=422833&pr_number=6038&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6038&signature=de50341c2143f0aaad8e037f48dab886f7f247dee429f204b77a4f379d1679a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ubuntu package setup reliability by configuring APT retries and timeouts.
  * Updated Ubuntu archive and security package sources to use HTTPS.
  * Safely handles environments where the optional mirror configuration is unavailable.

* **Tests**
  * Updated validation to confirm both Ubuntu archive and security HTTPS sources are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->