### PR TITLE
test(canon): cover content mapper watch edits

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_watch.rs
+++ b/crates/vize/tests/content_mapper_tsgo_watch.rs
@@ -79,6 +79,20 @@ fn install_packages(project_root: &Path) {
     std::os::windows::fs::symlink_dir(vue_source, vue_target).unwrap();
 }
 
+fn prepare_content_mapper_project(prefix: &str) -> tempfile::TempDir {
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir_in(cases_root)
+        .unwrap();
+    copy_fixture(&fixture, project.path());
+    install_packages(project.path());
+    project
+}
+
 struct WatchProcess {
     child: Child,
     output: String,
@@ -186,16 +200,7 @@ fn standard_tsgo_watch_enters_idle_with_authored_mapper_diagnostics() {
         tsgo.display()
     );
 
-    let fixture =
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
-    let cases_root = workspace_root().join("target/vize-tests/tests");
-    std::fs::create_dir_all(&cases_root).unwrap();
-    let project = tempfile::Builder::new()
-        .prefix("content-mapper-watch-")
-        .tempdir_in(cases_root)
-        .unwrap();
-    copy_fixture(&fixture, project.path());
-    install_packages(project.path());
+    let project = prepare_content_mapper_project("content-mapper-watch-");
 
     let mut clean = WatchProcess::spawn(&tsgo, project.path(), "tsconfig.json");
     clean.wait_for(0, "clean watch idle state", |output| {
@@ -216,4 +221,50 @@ fn standard_tsgo_watch_enters_idle_with_authored_mapper_diagnostics() {
             && output.contains("Watching for file changes")
     });
     broken.assert_running();
+}
+
+#[test]
+fn standard_tsgo_watch_revalidates_authored_vue_edits_and_repairs() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper watch edit conformance: {TSGO_ENV} is not set");
+        return;
+    };
+    assert!(
+        tsgo.is_file(),
+        "{TSGO_ENV} is not a file: {}",
+        tsgo.display()
+    );
+
+    let project = prepare_content_mapper_project("content-mapper-watch-edit-");
+    let child_path = project.path().join("src/Child.vue");
+    let valid_child = std::fs::read_to_string(&child_path).unwrap();
+    let invalid_child = valid_child.replace("count.toFixed(0)", "count.missing()");
+    assert_ne!(valid_child, invalid_child);
+
+    let mut watch = WatchProcess::spawn(&tsgo, project.path(), "tsconfig.json");
+    watch.wait_for(0, "initial clean watch idle state", |output| {
+        output.contains("Found 0 errors")
+            && output.contains("Watching for file changes")
+            && !output.contains("error TS")
+    });
+    watch.assert_running();
+
+    let edit_start = watch.output.len();
+    std::fs::write(&child_path, invalid_child).unwrap();
+    watch.wait_for(edit_start, "authored Vue edit diagnostic", |output| {
+        output.contains("src/Child.vue")
+            && output.contains("TS2339")
+            && output.contains("Property 'missing' does not exist on type 'number'")
+            && output.contains("Watching for file changes")
+    });
+    watch.assert_running();
+
+    let repair_start = watch.output.len();
+    std::fs::write(&child_path, valid_child).unwrap();
+    watch.wait_for(repair_start, "authored Vue repair diagnostics", |output| {
+        output.contains("Found 0 errors")
+            && output.contains("Watching for file changes")
+            && !output.contains("TS2339")
+    });
+    watch.assert_running();
 }

--- a/crates/vize/tests/content_mapper_tsgo_watch.rs
+++ b/crates/vize/tests/content_mapper_tsgo_watch.rs
@@ -237,11 +237,12 @@ fn standard_tsgo_watch_revalidates_authored_vue_edits_and_repairs() {
 
     let project = prepare_content_mapper_project("content-mapper-watch-edit-");
     let child_path = project.path().join("src/Child.vue");
-    let valid_child = std::fs::read_to_string(&child_path).unwrap().replace(
+    let original_child = std::fs::read_to_string(&child_path).unwrap();
+    let valid_child = original_child.replace(
         "<output>{{ count.toFixed(0) }}</output>",
         "<output>𠮷 {{ count.toFixed(0) }}</output>",
     );
-    assert!(valid_child.contains("𠮷 {{ count.toFixed(0) }}"));
+    assert_ne!(original_child, valid_child);
     let invalid_child = valid_child.replace("count.toFixed(0)", "count.missing()");
     assert_ne!(valid_child, invalid_child);
     std::fs::write(&child_path, &valid_child).unwrap();

--- a/crates/vize/tests/content_mapper_tsgo_watch.rs
+++ b/crates/vize/tests/content_mapper_tsgo_watch.rs
@@ -237,9 +237,14 @@ fn standard_tsgo_watch_revalidates_authored_vue_edits_and_repairs() {
 
     let project = prepare_content_mapper_project("content-mapper-watch-edit-");
     let child_path = project.path().join("src/Child.vue");
-    let valid_child = std::fs::read_to_string(&child_path).unwrap();
+    let valid_child = std::fs::read_to_string(&child_path).unwrap().replace(
+        "<output>{{ count.toFixed(0) }}</output>",
+        "<output>𠮷 {{ count.toFixed(0) }}</output>",
+    );
+    assert!(valid_child.contains("𠮷 {{ count.toFixed(0) }}"));
     let invalid_child = valid_child.replace("count.toFixed(0)", "count.missing()");
     assert_ne!(valid_child, invalid_child);
+    std::fs::write(&child_path, &valid_child).unwrap();
 
     let mut watch = WatchProcess::spawn(&tsgo, project.path(), "tsconfig.json");
     watch.wait_for(0, "initial clean watch idle state", |output| {
@@ -252,7 +257,7 @@ fn standard_tsgo_watch_revalidates_authored_vue_edits_and_repairs() {
     let edit_start = watch.output.len();
     std::fs::write(&child_path, invalid_child).unwrap();
     watch.wait_for(edit_start, "authored Vue edit diagnostic", |output| {
-        output.contains("src/Child.vue")
+        output.contains("src/Child.vue(10,23): error TS2339")
             && output.contains("TS2339")
             && output.contains("Property 'missing' does not exist on type 'number'")
             && output.contains("Watching for file changes")


### PR DESCRIPTION
## Summary
- add an exact Content Mapper watch edit/repair conformance test for authored Vue files
- share fixture setup between the existing watch idle test and the new edit cycle test

## Validation
- cargo test -p vize --test content_mapper_tsgo_watch -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

Refs #3984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791713607&installation_model_id=422833&pr_number=6039&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6039&signature=adbeb7b5c6a6d20efa99f7aee5057920f15c8a455011409fdab0172511c5359f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for watch mode detecting authored Vue file errors and recognizing repairs.
  - Verified that watch mode reports a TypeScript diagnostic introduced in a Vue file, then returns to a clean idle state after the issue is corrected.
  - Improved test setup reuse for TypeScript/Vue watch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->