### PR TITLE
test(maestro): cover call hierarchy follow-up routing

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -1,7 +1,5 @@
-//! IDE features for the LSP server. The module list below is the
-//! authoritative inventory:
-//! - Correctness: diagnostics, type checking and type information
-//! - Authoring: hover, completion, definition, references, code actions, rename, linked editing
+//! IDE features for the LSP server. Module inventory:
+//! - Correctness/authoring: diagnostics, type info, hover, completion, navigation, rename, linked editing
 //! - Structure: document/workspace symbols, selection ranges, semantic tokens, inlay hints
 //! - Ecosystem: router/i18n awareness, file rename, auto-import, code lens, document links
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
@@ -13,6 +11,8 @@ pub mod code_lens;
 pub mod completion;
 mod context;
 mod corsa_support;
+#[cfg(all(test, feature = "native"))]
+pub(crate) use corsa_support::{canonical_request_path, request_file_uri};
 pub mod cursor_context;
 pub mod declaration;
 pub mod definition;

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -24,6 +24,8 @@ mod svg_attribute;
 mod virtual_document;
 mod workspace_edit;
 
+#[cfg(test)]
+pub(crate) use canonical::canonical_request_path;
 pub(crate) use canonical::{
     CanonicalProjectOpenError, CanonicalSemanticPosition, CanonicalVirtualDocument,
     ComponentPropNavigationIdentities, ComponentPropSourceCache,

--- a/crates/vize_maestro/src/server/handlers/tests/requests.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests.rs
@@ -2,8 +2,10 @@ use super::*;
 use tower_lsp::{
     LspService,
     lsp_types::{
+        CallHierarchyIncomingCallsParams, CallHierarchyItem, CallHierarchyOutgoingCallsParams,
         CodeLensParams, DocumentLinkParams, FileRename, FoldingRangeParams, HoverParams,
-        InlayHintParams, SemanticTokensRangeParams, SignatureHelpParams, WorkspaceSymbolParams,
+        InlayHintParams, SemanticTokensRangeParams, SignatureHelpParams, SymbolKind,
+        WorkspaceSymbolParams,
     },
 };
 
@@ -197,6 +199,36 @@ enabled_missing_doc_request_returns_none!(
     implementation_missing_document_returns_none,
     &[("definition", true), ("typecheck", true)],
     |server, uri| server.goto_implementation(implementation_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    call_hierarchy_incoming_disabled_returns_none,
+    &[("definition", false), ("typecheck", true)],
+    |server, uri| server.incoming_calls(call_hierarchy_incoming_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    call_hierarchy_incoming_disabled_when_typecheck_is_off_returns_none,
+    &[("definition", true), ("typecheck", false)],
+    |server, uri| server.incoming_calls(call_hierarchy_incoming_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    call_hierarchy_incoming_missing_document_returns_none,
+    &[("definition", true), ("typecheck", true)],
+    |server, uri| server.incoming_calls(call_hierarchy_incoming_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    call_hierarchy_outgoing_disabled_returns_none,
+    &[("definition", false), ("typecheck", true)],
+    |server, uri| server.outgoing_calls(call_hierarchy_outgoing_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    call_hierarchy_outgoing_disabled_when_typecheck_is_off_returns_none,
+    &[("definition", true), ("typecheck", false)],
+    |server, uri| server.outgoing_calls(call_hierarchy_outgoing_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    call_hierarchy_outgoing_missing_document_returns_none,
+    &[("definition", true), ("typecheck", true)],
+    |server, uri| server.outgoing_calls(call_hierarchy_outgoing_params(&uri))
 );
 disabled_open_doc_request_returns_none!(
     references_disabled_returns_none,

--- a/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
@@ -2,6 +2,9 @@
 
 use vize_s0::cstr;
 
+#[cfg(feature = "native")]
+use crate::ide::{canonical_request_path, request_file_uri};
+
 use super::*;
 
 pub(super) fn service_with_options(
@@ -110,6 +113,47 @@ pub(super) fn declaration_params(uri: &Url) -> DeclParams {
 pub(super) fn implementation_params(uri: &Url) -> ImplParams {
     ImplParams {
         text_document_position_params: text_pos(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn call_hierarchy_item(uri: &Url) -> CallHierarchyItem {
+    #[cfg(feature = "native")]
+    let generated_uri = request_file_uri(&canonical_request_path(uri));
+    #[cfg(not(feature = "native"))]
+    let generated_uri = cstr!("file://{}.ts", uri.path());
+    CallHierarchyItem {
+        name: "message".to_string(),
+        kind: SymbolKind::VARIABLE,
+        tags: None,
+        detail: None,
+        uri: uri.clone(),
+        range: range(),
+        selection_range: range(),
+        data: Some(serde_json::json!({
+            "vizeCorsaRawCallHierarchyItem": {
+                "name": "message",
+                "kind": SymbolKind::VARIABLE,
+                "uri": generated_uri,
+                "range": range(),
+                "selectionRange": range(),
+            }
+        })),
+    }
+}
+
+pub(super) fn call_hierarchy_incoming_params(uri: &Url) -> CHIncomingParams {
+    CallHierarchyIncomingCallsParams {
+        item: call_hierarchy_item(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+pub(super) fn call_hierarchy_outgoing_params(uri: &Url) -> CHOutgoingParams {
+    CallHierarchyOutgoingCallsParams {
+        item: call_hierarchy_item(uri),
         work_done_progress_params: WorkDoneProgressParams::default(),
         partial_result_params: PartialResultParams::default(),
     }

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2776,7 +2776,7 @@ lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	s0	S0	stage	vize_s0	preferred	2
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/context.rs	88	s0	S0	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support.rs	54	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support.rs	56	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical.rs	3	s0	S0	stage	vize_s0	preferred	5
 lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/open.rs	146	s0	S0	stage	vize_s0	preferred	2
 lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/project.rs	5	s0	S0	stage	vize_s0	preferred	3
@@ -2952,7 +2952,7 @@ lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.
 lsp	LSP	test/dev	crates/vize_maestro/src/server/document_structure/folding/tests.rs	219	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/symbols.rs	14	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/lifecycle.rs	10	s0	S0	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests.rs	144	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests.rs	146	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests/params.rs	3	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/server/helpers.rs	15	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	test/dev	crates/vize_maestro/src/server/helpers/supersession_tests.rs	15	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/lsp-editor-feature-routing.test.ts
+++ b/tests/tooling/lsp-editor-feature-routing.test.ts
@@ -39,6 +39,25 @@ type RequestCase = {
 const position = { line: 1, character: 7 };
 const range = { start: position, end: position };
 
+function callHierarchyItem(uri: string) {
+  return {
+    name: "message",
+    kind: 13,
+    uri,
+    range,
+    selectionRange: range,
+    data: {
+      vizeCorsaRawCallHierarchyItem: {
+        name: "message",
+        kind: 13,
+        uri: `${uri}.vue.ts`,
+        range,
+        selectionRange: range,
+      },
+    },
+  };
+}
+
 const DISABLED_REQUESTS: RequestCase[] = [
   {
     method: "textDocument/hover",
@@ -166,6 +185,14 @@ const DISABLED_REQUESTS: RequestCase[] = [
   {
     method: "textDocument/prepareCallHierarchy",
     params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
+    method: "callHierarchy/incomingCalls",
+    params: (uri) => ({ item: callHierarchyItem(uri) }),
+  },
+  {
+    method: "callHierarchy/outgoingCalls",
+    params: (uri) => ({ item: callHierarchyItem(uri) }),
   },
   {
     method: "volar/client/autoInsert",


### PR DESCRIPTION
## Summary
- add handler guard coverage for call hierarchy incoming/outgoing follow-up requests
- keep follow-up routes inert when definition or typecheck support is disabled
- extend the live LSP disabled-feature routing matrix with the follow-up methods

Refs #3953.

## Validation
- `cargo fmt --check`
- `node --check tests/tooling/lsp-editor-feature-routing.test.ts`
- `git diff --check`
- `CARGO_BUILD_JOBS=2 cargo test -p vize_maestro server::handlers::tests::requests::call_hierarchy --features native`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791724481&installation_model_id=422833&pr_number=6041&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6041&signature=52480c98414582d700a22137a3135cf1c3cf9a0dcbc7427376c590b7e2e5b0f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded validation for incoming and outgoing call hierarchy requests.
  - Added coverage for disabled definition support and type-checking scenarios.
  - Added checks for requests involving missing documents.
  - Standardized call hierarchy fixtures and request parameters across testing environments.
  - Verified consistent routing behavior for both incoming and outgoing call hierarchy requests when the feature is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->