### PR TITLE
fix(release): retry matrix artifact downloads

### DIFF
--- a/legacy-tools/github/release-preflight-artifact-entries.mjs
+++ b/legacy-tools/github/release-preflight-artifact-entries.mjs
@@ -15,6 +15,8 @@ import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
 const artifactDownloadTimeoutMs = 120_000;
+const artifactDownloadRetries = 5;
+const artifactDownloadRetryDelayMs = 2_000;
 const artifactMaxBytes = 512 * 1024 * 1024;
 const artifactMaxEntries = 4_096;
 const artifactMaxUncompressedBytes = 512 * 1024 * 1024;
@@ -29,23 +31,17 @@ export async function downloadArtifactEntries({
   if (typeof url !== "string" || url.length === 0) {
     throw new Error(`Real Project Matrix artifact ${String(artifact.name)} has no download URL`);
   }
-  const response = await fetchImpl(url, {
-    headers: {
-      accept: "application/vnd.github+json",
-      authorization: `Bearer ${token}`,
-      "x-github-api-version": "2022-11-28",
-    },
-    signal: AbortSignal.timeout(artifactDownloadTimeoutMs),
+  const label = String(artifact.name);
+  const response = await fetchArtifactWithRetry({
+    artifactName: label,
+    fetchImpl,
+    limits,
+    token,
+    url,
   });
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download Real Project Matrix artifact ${String(artifact.name)}: ${response.status} ${response.statusText}`,
-    );
-  }
   const maxBytes = limits.maxBytes ?? artifactMaxBytes;
   const maxEntries = limits.maxEntries ?? artifactMaxEntries;
   const maxUncompressedBytes = limits.maxUncompressedBytes ?? artifactMaxUncompressedBytes;
-  const label = String(artifact.name);
   const scratch = mkdtempSync(join(tmpdir(), "vize-release-matrix-artifact-"));
   try {
     const archive = join(scratch, "artifact.zip");
@@ -71,6 +67,55 @@ export async function downloadArtifactEntries({
   } finally {
     rmSync(scratch, { recursive: true, force: true });
   }
+}
+
+async function fetchArtifactWithRetry({ artifactName, fetchImpl, limits, token, url }) {
+  const maxAttempts = limits.maxAttempts ?? artifactDownloadRetries + 1;
+  const retryDelayMs = limits.retryDelayMs ?? artifactDownloadRetryDelayMs;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: `Bearer ${token}`,
+          "x-github-api-version": "2022-11-28",
+        },
+        signal: AbortSignal.timeout(artifactDownloadTimeoutMs),
+      });
+    } catch (error) {
+      if (attempt === maxAttempts) throw error;
+      if (retryDelayMs > 0) await sleep(retryDelayMs);
+      continue;
+    }
+    if (response.ok) return response;
+    if (!isRetryableDownloadStatus(response.status) || attempt === maxAttempts) {
+      throw new Error(
+        `Failed to download Real Project Matrix artifact ${artifactName}: ${response.status} ${response.statusText}`,
+      );
+    }
+    await cancelResponseBody(response);
+    if (retryDelayMs > 0) await sleep(retryDelayMs);
+  }
+  throw new Error(`Failed to download Real Project Matrix artifact ${artifactName}`);
+}
+
+async function cancelResponseBody(response) {
+  const cancel = response.body?.cancel;
+  if (typeof cancel !== "function") return;
+  try {
+    await cancel.call(response.body);
+  } catch {
+    // A failed cancellation should not hide the original transient download error.
+  }
+}
+
+function isRetryableDownloadStatus(status) {
+  return status === 408 || status === 429 || (status >= 500 && status < 600);
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 export function exactMatchingEntries(entries, pattern, label) {

--- a/tests/tooling/release-preflight-artifact-download.test.ts
+++ b/tests/tooling/release-preflight-artifact-download.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { Buffer } from "node:buffer";
+import { createServer } from "node:http";
 import { Readable } from "node:stream";
 import { test } from "node:test";
 import { crc32 } from "node:zlib";
@@ -102,14 +103,92 @@ test("artifact download fails closed on missing URLs and error responses", async
     downloadArtifactEntries({
       artifact,
       token: "token",
+      limits: { maxAttempts: 1 },
       fetchImpl: async () => ({ ok: false, status: 500, statusText: "Server Error" }),
     }),
     /500 Server Error/,
   );
 });
 
+test("artifact download retries transient server failures before reading the archive", async () => {
+  let requests = 0;
+  const archive = storedZip([["summary.json", '{"ok":true}\n']]);
+  const server = createServer((_request, response) => {
+    requests += 1;
+    if (requests < 3) {
+      response.writeHead(503, { "content-type": "text/plain" });
+      response.end("temporarily unavailable");
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/zip" });
+    response.end(archive);
+  });
+  await listen(server);
+  try {
+    const address = server.address();
+    assert.ok(address != null && typeof address !== "string");
+    const entries = await downloadArtifactEntries({
+      artifact: {
+        ...artifact,
+        archive_download_url: `http://127.0.0.1:${address.port}/artifact.zip`,
+      },
+      token: "token",
+      limits: { retryDelayMs: 0 },
+    });
+    assert.equal(requests, 3);
+    assert.equal(entries.get("summary.json"), '{"ok":true}\n');
+  } finally {
+    await close(server);
+  }
+});
+
+test("artifact download cancels retryable response bodies before retrying", async () => {
+  let requests = 0;
+  let cancellations = 0;
+  const entries = await downloadArtifactEntries({
+    artifact,
+    token: "token",
+    limits: { retryDelayMs: 0 },
+    fetchImpl: async () => {
+      requests += 1;
+      if (requests < 3) {
+        return {
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+          body: {
+            cancel: async () => {
+              cancellations += 1;
+            },
+          },
+        };
+      }
+      return zipResponse([["summary.json", '{"ok":true}\n']]);
+    },
+  });
+  assert.equal(requests, 3);
+  assert.equal(cancellations, 2);
+  assert.equal(entries.get("summary.json"), '{"ok":true}\n');
+});
+
 function streamResponse(chunks: Iterable<Buffer>) {
   return { ok: true, status: 200, statusText: "OK", body: Readable.from(chunks) };
+}
+
+function listen(server: ReturnType<typeof createServer>) {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server: ReturnType<typeof createServer>) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((error) => (error == null ? resolve() : reject(error)));
+  });
 }
 
 function zipResponse(files: [string, string][]) {

--- a/tools/support/release/preflight_matrix_evidence.rs
+++ b/tools/support/release/preflight_matrix_evidence.rs
@@ -13,6 +13,8 @@ pub const REQUIRED_REAL_PROJECT_MATRIX_SHARD_COUNT: usize = 22;
 pub const REAL_PROJECT_MATRIX_WORKFLOW_NAME: &str = "Real Project Matrix";
 
 const ARTIFACT_DOWNLOAD_TIMEOUT_SECONDS: u64 = 120;
+const ARTIFACT_DOWNLOAD_RETRIES: u64 = 5;
+const ARTIFACT_DOWNLOAD_RETRY_DELAY_SECONDS: u64 = 3;
 const ARTIFACT_MAX_BYTES: u64 = 512 * 1024 * 1024;
 const ARTIFACT_MAX_ENTRIES: usize = 4_096;
 const ARTIFACT_MAX_UNCOMPRESSED_BYTES: u64 = 512 * 1024 * 1024;
@@ -98,6 +100,8 @@ fn download_artifact_entries_in(
     let archive = scratch.join("artifact.zip");
     let output = scratch.join("out");
     let timeout_seconds = ARTIFACT_DOWNLOAD_TIMEOUT_SECONDS.to_string();
+    let retry_count = ARTIFACT_DOWNLOAD_RETRIES.to_string();
+    let retry_delay_seconds = ARTIFACT_DOWNLOAD_RETRY_DELAY_SECONDS.to_string();
     let download = Command::new("curl")
         .args([
             "--fail-with-body",
@@ -106,6 +110,10 @@ fn download_artifact_entries_in(
             "--location",
             "--max-time",
             &timeout_seconds,
+            "--retry",
+            &retry_count,
+            "--retry-delay",
+            &retry_delay_seconds,
             "--header",
             "Accept: application/vnd.github+json",
             "--header",


### PR DESCRIPTION
## Summary
- retry Real Project Matrix artifact downloads in release preflight so transient GitHub 5xx responses do not roll back an otherwise green release
- mirror the retry behavior in the legacy JS evidence helper and cancel retryable response bodies before retrying
- add local-server and cancellation behavior tests for transient artifact download failures

## Verification
- cargo fmt --all --check
- node --test tests/tooling/release-preflight-artifact-download.test.ts
- node --test tests/tooling/release-preflight-runner.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check HEAD

## Release note
- This unblocks retrying the rolled-back release as the next minor release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release artifact downloads by automatically retrying transient failures, including rate limits, timeouts, and server errors.
  - Added up to five retry attempts with a three-second delay between attempts for greater download reliability.
  - Improved resilience when downloading artifacts through supported release-preflight workflows.

- **Tests**
  - Added coverage confirming that transient download failures are retried before succeeding.
  - Added validation for retry behavior, response cleanup, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->