### PR TITLE
docs(rules): expand accessibility rule guidance

### DIFF
--- a/docs/content/ja/rules/accessibility.md
+++ b/docs/content/ja/rules/accessibility.md
@@ -249,7 +249,57 @@ title: アクセシビリティルール
 </template>
 ```
 
+## `a11y/mouse-events-have-key-events`
+
+マウス hover のハンドラーを使う場合は、対応する focus と blur のハンドラーも必要です。
+
+デフォルトの重大度: `warning`。プリセット: `happy-path`、`nuxt`、`opinionated`。
+
+```vue
+<!-- 悪い -->
+<div @mouseenter="showPreview" @mouseleave="hidePreview">Preview</div>
+
+<!-- 良い -->
+<div tabindex="0" @mouseenter="showPreview" @mouseleave="hidePreview" @focus="showPreview" @blur="hidePreview">Preview</div>
+```
+
+## `a11y/no-i-for-icon`
+
+よく使われる icon 用 CSS class によって、`<i>` 要素が icon だけに使われている場合に報告します。
+
+デフォルトの重大度: `warning`。プリセット: `happy-path`、`nuxt`、`opinionated`。
+
+```vue
+<!-- 悪い -->
+<i class="material-icons">home</i>
+
+<!-- 良い -->
+<span class="material-icons" aria-hidden="true">home</span>
+<span class="sr-only">Home</span>
+```
+
+## `a11y/no-refer-to-non-existent-id`
+
+`for`、`aria-labelledby`、`aria-describedby` などの静的な ID 参照が、同じ template 内に存在する
+ID を指していることを要求します。
+
+デフォルトの重大度: `warning`。プリセット: `happy-path`、`nuxt`、`opinionated`。
+
+```vue
+<!-- 悪い -->
+<label for="email">Email</label>
+<input id="user-email" />
+
+<!-- 良い -->
+<label for="email">Email</label>
+<input id="email" />
+```
+
 ## 追加のアクセシビリティ ルール
+
+この分け方はドキュメントの詳しさだけの違いです。このページに載っている `a11y/*` はすべて通常の
+Patina アクセシビリティルールです。上のセクションは例付きで詳説済み、下の項目は同じ扱いで今後
+例を追加していくコンパクトな一覧です。
 
 `a11y/anchor-has-content` では、アンカー要素にアクセス可能なコンテンツが必要です。デフォルト: `warning`。
 プリセット: `happy-path`、`nuxt`、`opinionated`。
@@ -278,9 +328,6 @@ title: アクセシビリティルール
 `a11y/media-has-caption` にはメディア要素のキャプションが必要です。デフォルト: `warning`。プリセット:
 `happy-path`、`nuxt`、`opinionated`。
 
-`a11y/mouse-events-have-key-events` では、マウス ハンドラーを使用する場合、フォーカス ハンドラーとブラー ハンドラーが必要です。
-デフォルト: `warning`。プリセット: `happy-path`、`nuxt`、`opinionated`。
-
 `a11y/no-access-key` は、`accesskey` 属性を禁止します。デフォルト: `warning`。プリセット:
 `happy-path`、`nuxt`、`opinionated`。
 
@@ -290,14 +337,8 @@ title: アクセシビリティルール
 `a11y/no-distracting-elements` は、`<marquee>` や `<blink>` などの気が散る要素を禁止します。
 デフォルト: `warning`。プリセット: `happy-path`、`nuxt`、`opinionated`。
 
-`a11y/no-i-for-icon` は、アイコンのみの要素として `<i>` を使用することを推奨しません。デフォルト: `warning`。プリセット:
-`happy-path`、`nuxt`、`opinionated`。
-
 `a11y/no-redundant-roles` は、ネイティブ セマンティクスを複製する ARIA ロールを禁止します。デフォルト:
 `warning`。プリセット: `happy-path`、`nuxt`、`opinionated`。
-
-`a11y/no-refer-to-non-existent-id` は、欠落している ID への ARIA 参照を報告します。デフォルト: `warning`。
-プリセット: `happy-path`、`nuxt`、`opinionated`。
 
 `a11y/no-role-presentation-on-focusable` は `role="presentation"` または `role="none"` を禁止します
 フォーカス可能な要素。デフォルト: `error`。プリセット: `happy-path`、`nuxt`、`opinionated`。

--- a/docs/content/rules/accessibility.md
+++ b/docs/content/rules/accessibility.md
@@ -247,7 +247,56 @@ Good:
 </template>
 ```
 
+## `a11y/mouse-events-have-key-events`
+
+Requires focus and blur handlers when mouse hover handlers are used.
+
+Default severity: `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
+
+```vue
+<!-- Bad -->
+<div @mouseenter="showPreview" @mouseleave="hidePreview">Preview</div>
+
+<!-- Good -->
+<div tabindex="0" @mouseenter="showPreview" @mouseleave="hidePreview" @focus="showPreview" @blur="hidePreview">Preview</div>
+```
+
+## `a11y/no-i-for-icon`
+
+Reports `<i>` elements that are used only as icons through common icon CSS classes.
+
+Default severity: `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
+
+```vue
+<!-- Bad -->
+<i class="material-icons">home</i>
+
+<!-- Good -->
+<span class="material-icons" aria-hidden="true">home</span>
+<span class="sr-only">Home</span>
+```
+
+## `a11y/no-refer-to-non-existent-id`
+
+Requires static ID references such as `for`, `aria-labelledby`, and `aria-describedby` to point at IDs that exist in the same template.
+
+Default severity: `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
+
+```vue
+<!-- Bad -->
+<label for="email">Email</label>
+<input id="user-email" />
+
+<!-- Good -->
+<label for="email">Email</label>
+<input id="email" />
+```
+
 ## Additional Accessibility Rules
+
+The split here is documentation detail only: every `a11y/*` rule listed on this page is a normal
+Patina accessibility rule. Expanded sections above have examples; the compact entries below are
+listed until they receive the same treatment.
 
 `a11y/anchor-has-content` requires anchor elements to have accessible content. Default: `warning`.
 Presets: `happy-path`, `nuxt`, `opinionated`.
@@ -276,9 +325,6 @@ Presets: `nuxt`, `opinionated`.
 `a11y/media-has-caption` requires captions for media elements. Default: `warning`. Presets:
 `happy-path`, `nuxt`, `opinionated`.
 
-`a11y/mouse-events-have-key-events` requires focus and blur handlers when mouse handlers are used.
-Default: `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
-
 `a11y/no-access-key` disallows the `accesskey` attribute. Default: `warning`. Presets:
 `happy-path`, `nuxt`, `opinionated`.
 
@@ -288,14 +334,8 @@ Default: `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
 `a11y/no-distracting-elements` disallows distracting elements such as `<marquee>` and `<blink>`.
 Default: `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
 
-`a11y/no-i-for-icon` discourages using `<i>` as an icon-only element. Default: `warning`. Presets:
-`happy-path`, `nuxt`, `opinionated`.
-
 `a11y/no-redundant-roles` disallows ARIA roles that duplicate native semantics. Default:
 `warning`. Presets: `happy-path`, `nuxt`, `opinionated`.
-
-`a11y/no-refer-to-non-existent-id` reports ARIA references to missing IDs. Default: `warning`.
-Presets: `happy-path`, `nuxt`, `opinionated`.
 
 `a11y/no-role-presentation-on-focusable` disallows `role="presentation"` or `role="none"` on
 focusable elements. Default: `error`. Presets: `happy-path`, `nuxt`, `opinionated`.

--- a/tests/tooling/docs-accessibility-rules.test.ts
+++ b/tests/tooling/docs-accessibility-rules.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import { repoRoot } from "./_helpers/moonbit.ts";
+
+const promotedRules = [
+  "a11y/mouse-events-have-key-events",
+  "a11y/no-i-for-icon",
+  "a11y/no-refer-to-non-existent-id",
+];
+
+const locales = [
+  {
+    label: "English",
+    path: path.join(repoRoot, "docs/content/rules/accessibility.md"),
+    additionalHeading: "## Additional Accessibility Rules",
+    clarification: /The split here is documentation detail only/,
+  },
+  {
+    label: "Japanese",
+    path: path.join(repoRoot, "docs/content/ja/rules/accessibility.md"),
+    additionalHeading: "## 追加のアクセシビリティ ルール",
+    clarification: /ドキュメントの詳しさだけの違い/,
+  },
+];
+
+for (const locale of locales) {
+  test(`${locale.label} accessibility docs distinguish expanded examples from compact rule listings`, () => {
+    const source = fs.readFileSync(locale.path, "utf8");
+    const additionalIndex = source.indexOf(locale.additionalHeading);
+    assert.ok(additionalIndex > 0, "accessibility docs must keep an Additional section");
+
+    assert.match(
+      source.slice(additionalIndex),
+      locale.clarification,
+      "Additional rule placement must not imply a different implementation category",
+    );
+
+    for (const ruleId of promotedRules) {
+      const heading = `## \`${ruleId}\``;
+      const headingIndex = source.indexOf(heading);
+      assert.ok(headingIndex > 0, `${ruleId} must have an expanded documentation section`);
+      assert.ok(headingIndex < additionalIndex, `${ruleId} must appear before Additional`);
+      assert.equal(
+        source.slice(additionalIndex + locale.additionalHeading.length).includes(`\`${ruleId}\``),
+        false,
+        `${ruleId} must not also stay in the compact-only Additional list`,
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Clarify that expanded a11y sections and the Additional Accessibility Rules list differ only by documentation depth.
- Promote `a11y/mouse-events-have-key-events`, `a11y/no-i-for-icon`, and `a11y/no-refer-to-non-existent-id` into expanded English and Japanese examples.
- Add tooling coverage so the promoted rules do not drift back into the compact-only list.

## Context
Evaluated VOICEVOX/voicevox#3112 and pulled in the documentation clarity gap it exposed around disabled accessibility rules.

## Tests
- `git diff --check`
- `PATH=/Users/ubugeeei/.local/share/mise/installs/node/24.14.0/bin:$PATH node --test tests/tooling/docs-accessibility-rules.test.ts tests/tooling/docs-navigation.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791747953&installation_model_id=422833&pr_number=6046&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6046&signature=3fe2a15fdc7df8585c4cf08379f0bcbda7626643b1d74cbe228caa6b23d5ec05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded English and Japanese accessibility rule documentation with detailed explanations and Bad/Good examples for three rules.
  - Clarified that expanded rules and compact entries in the “Additional Accessibility Rules” section are documentation formats only.
  - Updated compact rule listings to avoid duplicating the newly expanded entries.

- **Tests**
  - Added coverage to verify documentation structure and prevent duplicate rule listings in both locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->