### PR TITLE
fix(patina): avoid component id-reference false positives

### DIFF
--- a/crates/vize_croquis/src/drawer/template/ids.rs
+++ b/crates/vize_croquis/src/drawer/template/ids.rs
@@ -32,8 +32,8 @@ const ID_REFERENCE_ATTRIBUTES: &[&str] = &[
 
 /// Get the `ElementIdKind` for an attribute name.
 #[inline]
-fn get_id_kind(attr_name: &str) -> Option<ElementIdKind> {
-    if attr_name == "id" {
+fn get_id_kind(attr_name: &str, is_component: bool) -> Option<ElementIdKind> {
+    let kind = if attr_name == "id" {
         Some(ElementIdKind::Id)
     } else if attr_name == "for" {
         Some(ElementIdKind::For)
@@ -43,6 +43,15 @@ fn get_id_kind(attr_name: &str) -> Option<ElementIdKind> {
         Some(ElementIdKind::OtherReference)
     } else {
         None
+    }?;
+
+    // Component props such as Quasar's `anchor` are not necessarily HTML ID
+    // references. Keep ARIA references checked, but do not infer non-ARIA
+    // reference semantics from component props.
+    if is_component && matches!(kind, ElementIdKind::OtherReference) {
+        None
+    } else {
+        Some(kind)
     }
 }
 
@@ -52,7 +61,11 @@ impl Drawer {
     /// Collects both:
     /// - Static IDs: `id="foo"`, `for="bar"`, etc.
     /// - Dynamic IDs: `:id="expr"`, `:for="expr"`, etc.
-    pub(in crate::drawer) fn collect_element_ids(&mut self, el: &ElementNode<'_>) {
+    pub(in crate::drawer) fn collect_element_ids(
+        &mut self,
+        el: &ElementNode<'_>,
+        is_component: bool,
+    ) {
         let scope_id = self.croquis.scopes.current_id();
         let in_loop = self.is_in_vfor_scope();
 
@@ -60,7 +73,7 @@ impl Drawer {
             match prop {
                 PropNode::Attribute(attr) => {
                     let attr_name = attr.name;
-                    if let Some(kind) = get_id_kind(attr_name)
+                    if let Some(kind) = get_id_kind(attr_name, is_component)
                         && let Some(value) = &attr.value
                     {
                         self.croquis.element_ids.push(ElementIdInfo {
@@ -88,7 +101,7 @@ impl Drawer {
                             }
                         };
 
-                        if let Some(kind) = get_id_kind(arg_name)
+                        if let Some(kind) = get_id_kind(arg_name, is_component)
                             && let Some(ref exp) = dir.exp
                         {
                             let content = match exp {

--- a/crates/vize_croquis/src/drawer/template/visit_element.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element.rs
@@ -72,7 +72,10 @@ impl Drawer {
         // Element attrs execute outside the v-slot props they define. They can
         // still reference same-element v-for aliases and petite-vue v-scope
         // bindings.
-        profile!("croquis.template.element_ids", self.collect_element_ids(el));
+        profile!(
+            "croquis.template.element_ids",
+            self.collect_element_ids(el, is_component)
+        );
 
         self.process_element_directives(el, scope_vars, is_component, tag);
         self.check_element_directive_refs(el, scope_vars);

--- a/crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs
+++ b/crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs
@@ -157,4 +157,28 @@ mod tests {
         let result = linter.lint_template(r#"<label :for="inputId">Name:</label>"#, "test.vue");
         assert_eq!(result.warning_count, 0);
     }
+
+    #[test]
+    fn test_invalid_missing_for_id() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<label for="email">Email</label>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_component_anchor_prop() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<QTooltip anchor="bottom middle">Help</QTooltip>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_native_anchor_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<button anchor="menu">Open</button>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
 }

--- a/crates/vize_patina/src/rules/html/helpers.rs
+++ b/crates/vize_patina/src/rules/html/helpers.rs
@@ -122,7 +122,12 @@ pub fn has_palpable_content(element: &ElementNode) -> bool {
         match child {
             TemplateChildNode::Text(text) if !text.content.trim().is_empty() => return true,
             TemplateChildNode::Interpolation(_) => return true,
-            TemplateChildNode::Element(el) if el.tag_type != ElementType::Template => return true,
+            TemplateChildNode::Element(el) if el.tag_type == ElementType::Template => {
+                if has_palpable_content(el) {
+                    return true;
+                }
+            }
+            TemplateChildNode::Element(_) => return true,
             _ => {}
         }
     }

--- a/crates/vize_patina/src/rules/html/no_empty_palpable_content.rs
+++ b/crates/vize_patina/src/rules/html/no_empty_palpable_content.rs
@@ -111,6 +111,16 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_with_template_child_content() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<p><template v-if="ready"><span>text</span></template></p>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
     fn test_valid_with_aria_label() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<p aria-label="description"></p>"#, "test.vue");

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -910,17 +910,6 @@
         "help": "Add rel=\"noopener noreferrer\" to links that open in a new tab: noopener protects window.opener, and noreferrer suppresses referrer data"
       },
       {
-        "ruleId": "html/no-empty-palpable-content",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 1,
-        "message": "[vize:html/no-empty-palpable-content] <p> element is empty but expects visible content",
-        "line": 36,
-        "column": 5,
-        "endLine": 36,
-        "endColumn": 47,
-        "help": "Add text content, child elements, or use aria-label for accessible content."
-      },
-      {
         "ruleId": "vue/no-template-target-blank",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -955,7 +944,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 7
+    "warningCount": 6
   },
   {
     "file": "app/components/list/Account.vue",

--- a/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
@@ -404,17 +404,6 @@
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
       },
       {
-        "ruleId": "html/no-empty-palpable-content",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 1,
-        "message": "[vize:html/no-empty-palpable-content] <p> element is empty but expects visible content",
-        "line": 130,
-        "column": 7,
-        "endLine": 130,
-        "endColumn": 62,
-        "help": "Add text content, child elements, or use aria-label for accessible content."
-      },
-      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -493,7 +482,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 15
+    "warningCount": 14
   },
   {
     "file": "app/components/BlueskyComments.vue",
@@ -822,17 +811,6 @@
     "file": "app/components/Code/FileTree.vue",
     "messages": [
       {
-        "ruleId": "html/no-empty-palpable-content",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 1,
-        "message": "[vize:html/no-empty-palpable-content] <li> element is empty but expects visible content",
-        "line": 60,
-        "column": 5,
-        "endLine": 60,
-        "endColumn": 47,
-        "help": "Add text content, child elements, or use aria-label for accessible content."
-      },
-      {
         "ruleId": "vue/attribute-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -867,7 +845,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 3
   },
   {
     "file": "app/components/Code/Header.vue",
@@ -1343,21 +1321,9 @@
   },
   {
     "file": "app/components/Diff/FileTree.vue",
-    "messages": [
-      {
-        "ruleId": "html/no-empty-palpable-content",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 1,
-        "message": "[vize:html/no-empty-palpable-content] <li> element is empty but expects visible content",
-        "line": 130,
-        "column": 5,
-        "endLine": 130,
-        "endColumn": 47,
-        "help": "Add text content, child elements, or use aria-label for accessible content."
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "app/components/Diff/Hunk.vue",

--- a/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
@@ -6808,21 +6808,10 @@
         "column": 19,
         "endLine": 38,
         "endColumn": 22
-      },
-      {
-        "ruleId": "html/no-empty-palpable-content",
-        "ruleDocsPath": "docs/content/rules/html.md",
-        "severity": 1,
-        "message": "[vize:html/no-empty-palpable-content] <p> element is empty but expects visible content",
-        "line": 52,
-        "column": 9,
-        "endLine": 52,
-        "endColumn": 25,
-        "help": "Add text content, child elements, or use aria-label for accessible content."
       }
     ],
     "errorCount": 2,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "packages/core/src/Tooltip/stories/Tooltip.story.vue",


### PR DESCRIPTION
## Summary

- ignore non-ARIA ID-reference attributes on Vue components so component props such as Quasar `anchor` do not trip `a11y/no-refer-to-non-existent-id`
- treat content inside `<template>` wrappers as palpable content for `html/no-empty-palpable-content`
- add regression tests for both cases observed while reviewing VOICEVOX/voicevox#3112

## Validation

- cargo test -p vize_patina no_refer_to_non_existent_id -- --nocapture
- cargo test -p vize_patina no_empty_palpable_content -- --nocapture
- cargo test -p vize_croquis
- cargo test -p vize_patina
- rust-script tools/commands/davinci/assertion-lint.rs
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791772574&installation_model_id=422833&pr_number=6050&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6050&signature=0039add536fb70a4fa63f270efa2a46c34e821ff16782a5e368c7aded7be8e6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accessibility validation for ID references on components, reducing false positives for valid component properties while continuing to flag invalid native references.
  - Updated empty-content checks to recognize meaningful content inside conditional `<template>` blocks.

- **Tests**
  - Added coverage for component ID properties, native reference validation, and palpable content nested within templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->