### PR TITLE
test(tooling): add primevue volt authored lsp oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 33, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 34, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -796,7 +796,8 @@
           "tests/_fixtures/_git/vue-flow",
           "tests/_fixtures/_git/vue-sonner",
           "tests/_fixtures/_git/varlet",
-          "tests/_fixtures/_git/vue-select"
+          "tests/_fixtures/_git/vue-select",
+          "tests/_fixtures/_git/primevue"
         ]
       },
       "evidence": {

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 33,
+    "minimumProjectCount": 34,
     "trackingIssue": 3952
   },
   "projects": [
@@ -590,6 +590,68 @@
         "corpusGlobs": ["apps/volt/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
+      },
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "apps/volt/components/landing/FilesCard.vue",
+          "symbol": "tags",
+          "usageAnchor": "v-model=\"tags\"",
+          "declarationAnchor": "const tags = ref(['new']);",
+          "hoverContains": ["const tags: string[]"],
+          "sharesComponentImporter": true,
+          "renameTo": "__vizeRenamedTags"
+        },
+        "componentBoundary": {
+          "importerFile": "apps/volt/components/landing/FilesCard.vue",
+          "componentFile": "apps/volt/volt/Button.vue",
+          "tagName": "Button",
+          "tagAnchor": "            <Button ",
+          "completionItemCount": 28,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 }
+          ],
+          "dependencyEdit": {
+            "anchor": "interface Props extends /* @vue-ignore */ ButtonProps {}",
+            "replacement": "interface Props extends /* @vue-ignore */ ButtonProps {\n    vizeOracleProbe?: boolean;\n}",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "apps/volt/volt/__VizeOracleButton.vue",
+          "renamedFile": "apps/volt/volt/__VizeOracleRenamedButton.vue",
+          "originalImportSpecifier": "@/volt/Button.vue",
+          "copiedImportSpecifier": "@/volt/__VizeOracleButton.vue",
+          "renamedImportSpecifier": "@/volt/__VizeOracleRenamedButton.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizePrimeVueVoltFileLifecycleMarker__"
+        }
       }
     },
     {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 33,
+      "authored-lsp": 34,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary
- add a PrimeVue Volt authored LSP oracle over the FilesCard tags binding and Button boundary
- pin the dependency-edit completion probe plus file copy/rename/delete lifecycle expectations
- raise the authored LSP registry and compatibility-ledger ratchets to 34 projects

Refs #3952

## Validation
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts
- CORSA_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/@typescript/typescript-darwin-arm64/lib/tsc VIZE_LSP_BIN=target/ci/vize REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=142 FIXTURE_SHARD_INDEX=6 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791779611&installation_model_id=422833&pr_number=6051&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6051&signature=636150261921893e832fcec905b8e13c9e3c2938fdf6ceba245d018dddba72f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded language-service validation to include the PrimeVue Volt fixture.
  - Added coverage for template bindings, component-boundary completion and dependency editing, and component file lifecycle scenarios.
  - Increased the validated authored-project fixture count from 33 to 34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->