### PR TITLE
test(tooling): add primevue authored lsp oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -324,10 +324,13 @@ function validateRatchets(oracles, fixtureMap, context) {
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),
-    context.registry.projects
-      .filter((project) => project.lspAuthoredOracle != null)
-      .map((project) => project.fixturePath)
-      .sort(compareCodepoints),
+    [
+      ...new Set(
+        context.registry.projects
+          .filter((project) => project.lspAuthoredOracle != null)
+          .map((project) => project.fixturePath),
+      ),
+    ].sort(compareCodepoints),
     "authored LSP oracle membership drifted",
   );
   deepEqual(

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 34,
+    "minimumProjectCount": 35,
     "trackingIssue": 3952
   },
   "projects": [
@@ -542,6 +542,68 @@
         "lsp"
       ],
       "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/primevue/src/button/Button.vue",
+          "symbol": "dataP",
+          "usageAnchor": ":data-p=\"dataP\"",
+          "declarationAnchor": "dataP() {",
+          "hoverContains": ["_Template expression_"],
+          "sharesComponentImporter": true,
+          "renameTo": "__vizeRenamedDataP"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/primevue/src/button/Button.vue",
+          "componentFile": "packages/primevue/src/badge/Badge.vue",
+          "tagName": "Badge",
+          "tagAnchor": "            <Badge ",
+          "completionItemCount": 28,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 }
+          ],
+          "dependencyEdit": {
+            "anchor": "    computed: {",
+            "replacement": "    props: {\n        vizeOracleProbe: Boolean\n    },\n    computed: {",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/primevue/src/badge/__VizeOracleBadge.vue",
+          "renamedFile": "packages/primevue/src/badge/__VizeOracleRenamedBadge.vue",
+          "originalImportSpecifier": "primevue/badge",
+          "copiedImportSpecifier": "../badge/__VizeOracleBadge.vue",
+          "renamedImportSpecifier": "../badge/__VizeOracleRenamedBadge.vue",
+          "markerInsertionAnchor": "<script>\n",
+          "markerSymbol": "__vizePrimeVueBadgeFileLifecycleMarker__"
+        }
+      },
       "typecheckPerformance": {
         "enabled": true,
         "compareTo": "vue-tsc",

--- a/tests/tooling/real-project-lsp-authored-oracle.test.ts
+++ b/tests/tooling/real-project-lsp-authored-oracle.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./support/fake-authored-lsp-session.ts";
 import { exerciseAuthoredLspOracle } from "./support/real-project-lsp-authored-oracle.ts";
 import {
+  normalizeDiagnostics,
   readOracleDocument,
   responseEvidence,
   sortLocations,
@@ -145,6 +146,20 @@ test("authored LSP utilities fail with portable evidence and diagnostics", () =>
     assert.deepEqual(
       responseEvidence({ uri: firstOutside, z: 1, ä: 2 }, 1, workspace),
       responseEvidence({ ä: 2, z: 1, uri: secondOutside }, 1, workspace),
+    );
+
+    const transientSessionDiagnostic = (session: string) => ({
+      code: 6263,
+      message:
+        `Module '/private/var/folders/x/T/vize-canon/editor/sessions/${session}/projects/0123abc/src/BaseButton.vue' was resolved to ` +
+        `'/private/var/folders/x/T/vize-canon/editor/sessions/${session}/projects/0123abc/src/BaseButton.d.vue', but '--allowArbitraryExtensions' is not set.`,
+      range: range(0, 1, 2),
+      severity: 1,
+      source: "typescript",
+    });
+    assert.deepEqual(
+      normalizeDiagnostics([transientSessionDiagnostic("session-A1")]),
+      normalizeDiagnostics([transientSessionDiagnostic("session-B2")]),
     );
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });

--- a/tests/tooling/support/real-project-lsp-authored-utils.ts
+++ b/tests/tooling/support/real-project-lsp-authored-utils.ts
@@ -203,13 +203,20 @@ export function normalizeDiagnostics(diagnostics: LspDiagnostic[]): string[] {
     .map((diagnostic) =>
       JSON.stringify({
         code: diagnostic.code,
-        message: diagnostic.message,
+        message: normalizeDiagnosticMessage(diagnostic.message),
         range: diagnostic.range,
         severity: diagnostic.severity,
         source: diagnostic.source,
       }),
     )
     .sort();
+}
+
+const VIZE_CANON_SESSION_PATH_PATTERN =
+  /(?:\/[^'"`\s]+)+\/vize-canon\/editor\/sessions\/session-[^/'"`\s]+\/projects\/[0-9a-fA-F]+\//gu;
+
+function normalizeDiagnosticMessage(message: string | undefined): string | undefined {
+  return message?.replace(VIZE_CANON_SESSION_PATH_PATTERN, "<vize-canon-session>/");
 }
 
 export function diagnosticEvidence(diagnostics: LspDiagnostic[]): DiagnosticEvidence {


### PR DESCRIPTION
## Summary
- add a PrimeVue authored LSP oracle for the Button.vue `dataP` binding and Badge component boundary
- raise the authored LSP project ratchet from 34 to 35
- dedupe compatibility-ledger authored LSP fixture paths when multiple project entries share one hydrated checkout
- normalize transient Vize/Corsa session roots in lifecycle diagnostic comparisons

Refs #3952

## VOICEVOX PR review
- VOICEVOX/voicevox#3112 is already represented in Vize by the VOICEVOX real-project check/lint/LSP oracle added in v0.416.0
- this change keeps that same approach: grow product-oracle coverage rather than copying downstream per-project linter disables into the defaults

## Validation
- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/real-project-lsp-authored-oracle.test.ts`
- `GITHUB_SHA=$(git rev-parse HEAD) CORSA_PATH="$PWD/node_modules/@typescript/typescript-darwin-arm64/lib/tsc" VIZE_LSP_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize--p0-3952-authored-lsp-34/target/ci/vize REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=142 FIXTURE_SHARD_INDEX=5 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791784707&installation_model_id=422833&pr_number=6052&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6052&signature=e7b3d3c0c6afc94655a8be6e3803e0b332665f3a35adee25f454c38c7bdf561e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic consistency by removing session-specific paths from diagnostic comparisons.
  * Prevented duplicate project fixtures from affecting authored LSP validation.

* **Tests**
  * Expanded real-project language service coverage with additional PrimeVue component scenarios.
  * Added validation for template bindings, component boundaries, file lifecycle behavior, and portable diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->