### PR TITLE
test(tooling): add primevue showcase authored lsp oracle

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 35,
+    "minimumProjectCount": 36,
     "trackingIssue": 3952
   },
   "projects": [
@@ -738,6 +738,69 @@
         "lsp"
       ],
       "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "apps/showcase/components/doc/DocCopyMarkdown.vue",
+          "symbol": "menuItems",
+          "usageAnchor": ":model=\"menuItems\"",
+          "declarationAnchor": "menuItems: [",
+          "hoverContains": ["menuItems"],
+          "renameTo": "__vizePrimeVueShowcaseMenuItems"
+        },
+        "componentBoundary": {
+          "importerFile": "apps/showcase/components/doc/DocComponent.vue",
+          "componentFile": "apps/showcase/components/doc/DocCopyMarkdown.vue",
+          "tagName": "DocCopyMarkdown",
+          "tagAnchor": "                            <DocCopyMarkdown ",
+          "completionItemCount": 30,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "doc-type", "rank": 28 },
+            { "label": "component-name", "rank": 29 }
+          ],
+          "dependencyEdit": {
+            "anchor": "        docType: {\n            type: String,\n            default: 'component'\n        }\n",
+            "replacement": "        docType: {\n            type: String,\n            default: 'component'\n        },\n        vizeOracleProbe: {\n            type: Boolean,\n            default: false\n        }\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "apps/showcase/components/doc/__VizeOracleDocCopyMarkdown.vue",
+          "renamedFile": "apps/showcase/components/doc/__VizeOracleRenamedDocCopyMarkdown.vue",
+          "originalImportSpecifier": "./DocCopyMarkdown.vue",
+          "copiedImportSpecifier": "./__VizeOracleDocCopyMarkdown.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedDocCopyMarkdown.vue",
+          "markerInsertionAnchor": "<script>\n",
+          "markerSymbol": "__vizePrimeVueShowcaseFileLifecycleMarker__"
+        }
+      },
       "typecheckPerformance": {
         "enabled": true,
         "compareTo": "vue-tsc",


### PR DESCRIPTION
## Summary
- add the PrimeVue Showcase authored LSP oracle for template binding, component boundary completion, and file lifecycle behavior
- ratchet authored LSP oracle coverage from 35 to 36 projects

## Verification
- cargo build --profile ci -p vize
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/real-project-lsp-authored-oracle.test.ts && git diff --check
- REPORT_DIR=$(mktemp -d /tmp/vize-primevue-showcase-lsp.XXXXXX) GITHUB_SHA=$(git rev-parse HEAD) CORSA_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/@typescript/typescript-darwin-arm64/lib/tsc VIZE_LSP_BIN=$PWD/target/ci/vize REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_REPORT_DIR=$REPORT_DIR FIXTURE_SHARD_COUNT=142 FIXTURE_SHARD_INDEX=7 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts

Refs #3952

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791790512&installation_model_id=422833&pr_number=6053&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6053&signature=611cdf671cd6793c5637a16470a07e4043df3102e616df81b0e2177ec6be1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Vue ecosystem validation coverage with additional template-binding, component-boundary, and file-lifecycle scenarios.
  - Updated project coverage requirements to reflect the expanded test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->