### PR TITLE
fix(musea-vrt): run through pnpm bin shim

### DIFF
--- a/npm/builder/vite-musea/src/cli/index.test.ts
+++ b/npm/builder/vite-musea/src/cli/index.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+void test("runs when invoked through a symlinked pnpm bin entrypoint", async (t) => {
+  const workspace = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-vrt-bin-"));
+  t.after(() => fs.promises.rm(workspace, { force: true, recursive: true }));
+
+  const entrypoint = path.join(packageRoot, "src", "cli", "index.ts");
+  const shimEntrypoint = path.join(
+    workspace,
+    "node_modules",
+    "@vizejs",
+    "vite-plugin-musea",
+    "dist",
+    "cli",
+    "index.ts",
+  );
+  await fs.promises.mkdir(path.dirname(shimEntrypoint), { recursive: true });
+  await fs.promises.symlink(entrypoint, shimEntrypoint);
+
+  const result = spawnSync(process.execPath, ["--import", "tsx", shimEntrypoint, "--help"], {
+    cwd: packageRoot,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Musea VRT - Visual Regression Testing for Component Gallery/u);
+  assert.match(result.stdout, /Usage:\n\s+musea-vrt \[command\] \[options\]/u);
+});

--- a/npm/builder/vite-musea/src/cli/index.ts
+++ b/npm/builder/vite-musea/src/cli/index.ts
@@ -23,6 +23,7 @@
  */
 
 import path from "node:path";
+import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { ArtFileInfo } from "../types/index.js";
 import { scanArtFiles, parseArtFile } from "./utils.js";
@@ -292,5 +293,13 @@ if (isDirectRun()) {
 
 function isDirectRun(): boolean {
   const entrypoint = process.argv[1];
-  return entrypoint ? fileURLToPath(import.meta.url) === path.resolve(entrypoint) : false;
+  if (!entrypoint) {
+    return false;
+  }
+
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(path.resolve(entrypoint));
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- compare the Musea VRT CLI entrypoint using realpaths so pnpm .bin shims still execute the CLI
- add a symlinked entrypoint regression test for the pnpm layout

## Verification
- ./node_modules/.bin/vp exec tsx --test src/cli/index.test.ts
- ./node_modules/.bin/vp fmt npm/builder/vite-musea/src/cli/index.ts npm/builder/vite-musea/src/cli/index.test.ts
- ./node_modules/.bin/vp run --filter @vizejs/vite-plugin-musea check
- git diff --check

## Notes
- ./node_modules/.bin/vp run --filter @vizejs/vite-plugin-musea test currently reaches this new regression and then fails in existing art/native expectation tests unrelated to the CLI entrypoint guard.

Fixes #6036

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791790735&installation_model_id=422833&pr_number=6054&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6054&signature=605042dd377c295df1aede746c02cea71340b1b26db822adc0228d1b95300d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI execution when launched through symlinked package entry points.
  - CLI path detection now handles missing or unresolvable entry points without crashing.

- **Tests**
  - Added coverage verifying that the CLI displays its help output and exits successfully when invoked through a symlink.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->