### PR TITLE
docs(davinci): document impeto operations

### DIFF
--- a/crates/vize_impeto/src/lib.rs
+++ b/crates/vize_impeto/src/lib.rs
@@ -14,6 +14,10 @@
 //! The crate is `no_std + alloc` from birth so S3 artifacts can be printed,
 //! validated, and replayed on the same portability lane as the earlier Davinci
 //! stage libraries.
+//!
+//! The operation semantics review point lives in
+//! [`davinci-road/plan/impeto-ops.md`](../../../davinci-road/plan/impeto-ops.md)
+//! and is kept in sync with [`op::OpKind`] plus the Lean reference runner.
 
 #![no_std]
 

--- a/davinci-road/plan/folio-format-impeto.md
+++ b/davinci-road/plan/folio-format-impeto.md
@@ -20,8 +20,9 @@ Sections, in struct declaration order:
 | `[s3-folio.edges]`   | `from=<n> to=<n> kind=<dom-order\|effect-order\|data-dependency> effect=<n\|->` |
 | `[s3-folio.effects]` | `id=<n> owner=<n> region=<n> span=<start>:<end>`                                |
 
-The optional id value is spelled `-` when absent. The op mnemonic set is the
-P3-1 generalization of Vapor's OperationNode family:
+The optional id value is spelled `-` when absent. The op mnemonic set and its
+VDOM/Vapor meaning are defined in
+[`impeto-ops.md`](./impeto-ops.md). The P3-1 mnemonic set is:
 `impeto.set-prop`, `impeto.set-dynamic-props`, `impeto.set-text`,
 `impeto.set-event`, `impeto.set-html`, `impeto.set-template-ref`,
 `impeto.insert-node`, `impeto.prepend-node`, `impeto.directive`, `impeto.if`,

--- a/davinci-road/plan/impeto-ops.md
+++ b/davinci-road/plan/impeto-ops.md
@@ -1,0 +1,102 @@
+# Impeto Op Reference
+
+Impeto is S3's shared backend contract. S2 owns the authored semantic tree;
+Impeto owns the flat operation stream, explicit regions, state edges, effect
+scopes, and the decisions that DOM, VDOM, Vapor, and SSR must not rediscover in
+separate emitters.
+
+This page is the human reference for the 16 stable operation mnemonics. The
+normative executable companion is the Lean package in `formal/impeto/`, which
+parses the same S3 Folio text and records the first VDOM/Vapor trace labels.
+Folio remains the concrete interchange syntax; see
+[`folio-format-impeto.md`](./folio-format-impeto.md).
+
+## Program Model
+
+An S3 Folio program has four order-bearing sections:
+
+| section | role |
+| --- | --- |
+| `regions` | Root and child regions. A child records its parent region and owning op. |
+| `ops` | Flat operation records: id, mnemonic, region, optional effect, and span. |
+| `edges` | Explicit ordering and dependency edges between op ids. |
+| `effects` | Effect scopes owned by dynamic ops. |
+
+The phase name describes which invariants consumers may assume:
+
+| phase | meaning |
+| --- | --- |
+| `built` | S2 order has been lowered into S3 ids. Partition facts can exist beside the program, but optional scheduling has not committed. |
+| `partitioned` | Static/dynamic partition decisions have been validated for downstream readers. |
+| `scheduled` | Effect/data ordering has been committed; backends consume the schedule rather than reordering on their own. |
+
+`effect=-` means the op is structural or statically decided in the current
+program. An effect id means the op participates in update ordering and owns or
+belongs to an effect scope. `dom-order` keeps authored sibling/binding order,
+`effect-order` keeps observable dynamic order, and `data-dependency` is reserved
+for fact/schedule edges that are not DOM order.
+
+## Operation Semantics
+
+| mnemonic | source meaning | VDOM trace | Vapor trace | notes |
+| --- | --- | --- | --- | --- |
+| `impeto.set-prop` | Assign one named property, attribute, model channel, or sync target. | `patch-prop` | `assign-prop` | Usually dynamic; `v-model` and `vue.sync` lower here until a later pass specializes them. |
+| `impeto.set-dynamic-props` | Assign an object-shaped property bag or other dynamic prop group. | `patch-dynamic-props` | `assign-dynamic-props` | Covers argument-less `v-bind` and CSS-bind carrier facts in the first lowering slice. |
+| `impeto.set-text` | Set literal text, interpolation text, or `v-text` output. | `set-text` | `text-effect` | Literal S2 text can stay effectless; interpolation and `v-text` are dynamic. |
+| `impeto.set-event` | Attach an event listener and its modifiers/options. | `patch-event` | `listen` | The op records listener placement; later passes may split handler shape decisions into facts. |
+| `impeto.set-html` | Assign trusted raw HTML from `v-html`. | `set-html` | `html-effect` | Always a dynamic sink unless a future verifier proves a static authored value. |
+| `impeto.set-template-ref` | Publish a template ref binding for backend materialization. | `set-template-ref` | `template-ref` | Reserved in the op family before the lowering path starts emitting it directly. |
+| `impeto.insert-node` | Materialize a host node in the current region. | `create-element` | `create-node` | Used for elements and comments in the first S2 to S3 lowering slice. |
+| `impeto.prepend-node` | Materialize a host node before the current insertion point. | `prepend-node` | `prepend-node` | Reserved for anchor-sensitive insertion decisions. |
+| `impeto.directive` | Apply a Vue runtime directive or directive-like marker. | `apply-directive` | `directive-effect` | Covers generic directives plus `v-once`, `v-memo`, `v-show`, and `v-cloak` in the first slice. |
+| `impeto.if` | Select one conditional child region. | `branch` | `conditional-effect` | Owns one region per branch; dynamic partition propagates into branch children. |
+| `impeto.for` | Iterate a child region for a source collection. | `iterate` | `list-effect` | Owns the repeated region; keyed and unkeyed update laws are P3-11 work. |
+| `impeto.create-component` | Create a component boundary and pass its props, events, and slots. | `create-component` | `component-effect` | Component children inherit dynamic partition in the first lowering slice. |
+| `impeto.slot-outlet` | Render or describe a slot outlet/scope bridge. | `render-slot` | `slot-effect` | Used for S2 slots and slot-scope binding records. |
+| `impeto.get-text-child` | Resolve an existing text child reference. | `get-text-child` | `get-text-child` | Structural reference op; it should not invent dynamic work by itself. |
+| `impeto.child-ref` | Resolve the first child anchor/reference for a region owner. | `child-ref` | `child-ref` | Structural reference op used by backend scheduling and insertion. |
+| `impeto.next-ref` | Resolve the next sibling anchor/reference. | `next-ref` | `next-ref` | Structural reference op used when stable insertion points matter. |
+
+The VDOM and Vapor labels above are intentionally small observations, not code
+generation byte strings. They are the trace vocabulary used by the first Lean
+reference runner so semantic drift appears before optional passes rewrite or
+schedule the op stream.
+
+## S2 Lowering Commitments
+
+The first S2 to S3 bridge emits `built` programs. S3 op ids follow S2 page
+order: owner op, attached bindings, then owned child regions. Every lowered op
+also receives a partition fact beside the program, so SSR and later thin paths
+can read canonical partition decisions without traversing S3 ops.
+
+| S2 form | Impeto op |
+| --- | --- |
+| Element | `impeto.insert-node` |
+| Component | `impeto.create-component` |
+| Text | `impeto.set-text` |
+| Interpolation | `impeto.set-text` |
+| Comment | `impeto.insert-node` |
+| If | `impeto.if` |
+| For | `impeto.for` |
+| Slot | `impeto.slot-outlet` |
+| Named `v-bind` | `impeto.set-prop` |
+| Argument-less `v-bind` | `impeto.set-dynamic-props` |
+| `v-on` | `impeto.set-event` |
+| `v-model` / `vue.sync` | `impeto.set-prop` |
+| Slot content/scope binding | `impeto.slot-outlet` |
+| Generic directive / `v-once` / `v-memo` / `v-show` / `v-cloak` | `impeto.directive` |
+| CSS bind carrier | `impeto.set-dynamic-props` |
+| `v-html` | `impeto.set-html` |
+| `v-text` | `impeto.set-text` |
+
+Dynamic partition creates an effect scope and an `effect-order` edge from the
+previous dynamic op. Static partition leaves the op effectless. This is only the
+initial lowering discipline; P3-10 extraction and later scheduling must either
+prove the exported partition is preserved or rerun validation before consumers
+read it.
+
+## Review Point
+
+P3-5 lands before optional passes. A new Impeto op, a changed mnemonic, or a
+changed Lean trace label must update this page, the Rust `OpKind` table, the
+Lean parser/semantics, and the sync test in the same PR.

--- a/davinci-road/plan/phase-3-records/p3-5.md
+++ b/davinci-road/plan/phase-3-records/p3-5.md
@@ -1,0 +1,32 @@
+# P3-5 - Impeto op reference doc
+
+This slice records the S3 operation semantics before optional passes start
+rewriting or scheduling the op stream.
+
+## Boundary
+
+P3-5 is documentation plus sync coverage. It does not add a new Impeto op, does
+not change the S2 to S3 lowering behavior, and does not close P3-3 or P3-4.
+Those tasks still own generated fixture coverage, fuzz extension, and backend
+differential wiring.
+
+## Decisions
+
+| subject | decision |
+| --- | --- |
+| Reference home | `davinci-road/plan/impeto-ops.md` is the human op reference. |
+| Normative companion | `formal/impeto/` remains the executable semantics companion for VDOM/Vapor traces. |
+| Concrete syntax | S3 Folio remains the interchange format; the format page links to the op reference instead of duplicating semantics. |
+| Rustdoc link | `vize_impeto` crate docs point to the op reference so API readers hit the review point before adding ops. |
+| Sync guard | The tooling test compares Rust mnemonics, Lean parser entries, Lean trace labels, and the markdown table. |
+
+## Mechanical witnesses
+
+- `node --test tests/tooling/davinci-impeto-ops-doc.test.ts tests/tooling/davinci-lean-reference.test.ts tests/tooling/source-file-lengths.test.ts`
+- `git diff --check`
+
+## Follow-up
+
+P3-3 still needs TS-17 snapshots, TS-20 S2 to S3 fuzz coverage, and lattice
+inputs. P3-4 still needs generated S3 fixtures from the Rust lowering path and
+compiled backend behavior traces compared against the Lean reference.

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -10,7 +10,7 @@
 - [x] P3-2 Reactivity lattice fact group v1
 - [ ] P3-3 S2→S3 lowering + shared partition
 - [ ] P3-4 Lean reference semantics + differential runner
-- [ ] P3-5 Impeto op reference doc (before optional passes)
+- [x] P3-5 Impeto op reference doc (before optional passes)
 - [ ] P3-6 Vapor backend on S3
 - [ ] P3-7 VDOM patch flags from lattice facts
 - [ ] P3-8 SSR thin path
@@ -71,7 +71,8 @@ workflow.
 meaning under both interpretations, written **before any optional pass
 lands** (MIR anti-lesson); Lean file is the normative companion; Folio is the
 concrete syntax. _Accept:_ review point — signed off; doc cross-linked from
-rustdoc.
+rustdoc. _Landed 2026-09-12:_ see
+[P3-5 record](./phase-3-records/p3-5.md).
 
 **P3-6 Vapor on S3.** `vize_atelier_vapor` lowers S2→S3→generate with full
 semantic context; deletes the run-then-discard double transform

--- a/tests/tooling/davinci-impeto-ops-doc.test.ts
+++ b/tests/tooling/davinci-impeto-ops-doc.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(repoRoot, ...segments), "utf8");
+}
+
+function rustMnemonics(): string[] {
+  const rust = readRepoFile("crates", "vize_impeto", "src", "op", "kind.rs");
+  return [
+    ...new Set(
+      [...rust.matchAll(/Self::[A-Za-z]+ => "(impeto\.[^"]+)"/gu)].map(
+        (match) => match[1],
+      ),
+    ),
+  ];
+}
+
+function leanParserMnemonics(): string[] {
+  const syntax = readRepoFile("formal", "impeto", "Impeto", "Syntax.lean");
+  return [...syntax.matchAll(/\| "(impeto\.[^"]+)" => some \.[A-Za-z]+/gu)].map(
+    (match) => match[1],
+  );
+}
+
+function tableRows(): Map<string, { vapor: string; vdom: string }> {
+  const doc = readRepoFile("davinci-road", "plan", "impeto-ops.md");
+  const rows = new Map<string, { vapor: string; vdom: string }>();
+
+  for (const line of doc.split("\n")) {
+    const match = line.match(
+      /^\| `(impeto\.[^`]+)` \| .* \| `([^`]+)` \| `([^`]+)` \| .* \|$/u,
+    );
+    if (match) {
+      rows.set(match[1], { vdom: match[2], vapor: match[3] });
+    }
+  }
+
+  return rows;
+}
+
+function leanTraceLabels(functionName: "interpretVDom" | "interpretVapor"): string[] {
+  const semantics = readRepoFile("formal", "impeto", "Impeto", "Semantics.lean");
+  const start = semantics.indexOf(`def ${functionName}`);
+  assert.notEqual(start, -1, `${functionName} is missing`);
+  const end = semantics.indexOf("\ndef ", start + 1);
+  const block = semantics.slice(start, end === -1 ? undefined : end);
+  return [...block.matchAll(/\| \.[A-Za-z]+ => "([^"]+)"/gu)].map((match) => match[1]);
+}
+
+test("P3-5 Impeto op reference covers the Rust mnemonic set exactly once", () => {
+  const expected = rustMnemonics();
+  const rows = tableRows();
+
+  assert.deepEqual([...rows.keys()], expected);
+  assert.deepEqual(leanParserMnemonics(), expected);
+});
+
+test("P3-5 Impeto op reference records the executable Lean trace labels", () => {
+  const rows = [...tableRows().values()];
+
+  assert.deepEqual(
+    rows.map((row) => row.vdom),
+    leanTraceLabels("interpretVDom"),
+  );
+  assert.deepEqual(
+    rows.map((row) => row.vapor),
+    leanTraceLabels("interpretVapor"),
+  );
+});
+
+test("P3-5 Impeto op reference is cross-linked from Folio docs and rustdoc", () => {
+  const folio = readRepoFile("davinci-road", "plan", "folio-format-impeto.md");
+  const lib = readRepoFile("crates", "vize_impeto", "src", "lib.rs");
+  const phase = readRepoFile("davinci-road", "plan", "phase-3.md");
+
+  assert.match(folio, /\[`impeto-ops\.md`\]\(\.\/impeto-ops\.md\)/u);
+  assert.match(lib, /\[`davinci-road\/plan\/impeto-ops\.md`\]/u);
+  assert.match(phase, /P3-5 Impeto op reference doc/u);
+  assert.match(phase, /\[P3-5 record\]\(\.\/phase-3-records\/p3-5\.md\)/u);
+});


### PR DESCRIPTION
## Summary
- add the P3-5 Impeto operation reference before optional passes land
- cross-link the reference from the S3 Folio docs and vize_impeto rustdoc
- add a tooling guard that keeps the markdown table aligned with Rust OpKind and the Lean trace labels

## Validation
- node --test tests/tooling/davinci-impeto-ops-doc.test.ts tests/tooling/davinci-lean-reference.test.ts tests/tooling/source-file-lengths.test.ts
- cargo fmt --all -- --check
- git diff --check

Stacked on #6063.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791810690&installation_model_id=422833&pr_number=6064&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6064&signature=96bffb63d5ae36b18a4ab1bfac2928c59ec9c81ee9908e1f42c58d2715264195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->