### PR TITLE
feat(davinci): add vapor s3 bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,10 @@ dependencies = [
  "vize_carton",
  "vize_croquis",
  "vize_davinci",
+ "vize_impeto",
+ "vize_s1",
+ "vize_s1_to_s2",
+ "vize_s2_to_s3",
 ]
 
 [[package]]

--- a/crates/vize_atelier_vapor/Cargo.toml
+++ b/crates/vize_atelier_vapor/Cargo.toml
@@ -12,6 +12,10 @@ metadata.vize.stability = "experimental"
 vize_carton = { workspace = true }
 vize_atelier_core = { workspace = true }
 vize_croquis = { workspace = true }
+vize_s1 = { workspace = true }
+vize_s1_to_s2 = { workspace = true }
+vize_s2_to_s3 = { workspace = true }
+vize_s3 = { workspace = true }
 
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }

--- a/crates/vize_atelier_vapor/src/compile.rs
+++ b/crates/vize_atelier_vapor/src/compile.rs
@@ -5,6 +5,7 @@
 
 use crate::generate::generate_vapor;
 use crate::lower as vapor_lower;
+use crate::s3::{self, VaporS3BridgeOptions, VaporS3BridgeStatus};
 use vize_atelier_core::{
     CompilerError, Namespace,
     lane::transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id,
@@ -218,6 +219,19 @@ fn compile_vapor_inner_with_stack<'a>(
         );
     }
 
+    let s3_bridge_status = s3::lower_source_for_vapor(
+        allocator,
+        source,
+        VaporS3BridgeOptions {
+            ssr: options.ssr,
+            custom_renderer: options.custom_renderer,
+            experimental_in_tag_comments: options.experimental_in_tag_comments,
+            experimental_patterned_template: options.experimental_patterned_template,
+            template_syntax,
+            has_custom_elements: !custom_elements.is_empty(),
+        },
+    );
+
     // Transform to Vapor IR
     let binding_metadata = options.binding_metadata.clone();
     let transform_opts = TransformOptions {
@@ -241,8 +255,11 @@ fn compile_vapor_inner_with_stack<'a>(
     );
 
     // Lower to Vapor IR
-    let (ir, transform_diagnostics) =
+    let (ir, mut transform_diagnostics) =
         vapor_lower::transform_to_ir_with_diagnostics(allocator, &root, source);
+    if let VaporS3BridgeStatus::Rejected(diagnostics) = s3_bridge_status {
+        transform_diagnostics.extend(diagnostics);
+    }
 
     // Generate Vapor code
     let result = generate_vapor(&ir, binding_metadata.as_ref());

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -15,6 +15,8 @@ pub mod generate;
 pub mod generators;
 pub mod ir;
 pub mod lower;
+#[doc(hidden)]
+pub mod s3;
 pub mod steps;
 
 #[cfg(test)]

--- a/crates/vize_atelier_vapor/src/s3.rs
+++ b/crates/vize_atelier_vapor/src/s3.rs
@@ -1,0 +1,209 @@
+//! S3 bridge for the Vapor compile path.
+//!
+//! P3-6 moves Vapor toward the canonical S2->S3 backend route. The first
+//! production slice keeps today's payload-rich Vapor IR generator in place, but
+//! every supported Vapor compile now builds and verifies the S3 program beside
+//! it. That makes the S3 contract observable in the real path before payload
+//! ownership moves out of the legacy lowering.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use vize_atelier_core::TemplateSyntaxMode;
+use vize_carton::{Allocator, String, cstr, profile, profiler::global_profiler};
+use vize_s1::SurfaceParseOptions;
+use vize_s3::verify::verify;
+
+/// Option subset that decides whether the S3 bridge can mirror this compile.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct VaporS3BridgeOptions {
+    pub(crate) ssr: bool,
+    pub(crate) custom_renderer: bool,
+    pub(crate) experimental_in_tag_comments: bool,
+    pub(crate) experimental_patterned_template: bool,
+    pub(crate) template_syntax: TemplateSyntaxMode,
+    pub(crate) has_custom_elements: bool,
+}
+
+/// Result of attempting the S3 bridge for one Vapor compile.
+#[derive(Debug)]
+pub(crate) enum VaporS3BridgeStatus {
+    /// The input uses an option shape S3 does not model yet.
+    Skipped,
+    /// S1->S2->S3 built and verified.
+    Accepted,
+    /// S3 was selected but failed an invariant.
+    Rejected(std::vec::Vec<String>),
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg(test)]
+pub(crate) struct VaporS3BridgeStats {
+    pub(crate) attempts: u64,
+    pub(crate) accepted: u64,
+    pub(crate) skipped: u64,
+    pub(crate) rejected: u64,
+}
+
+static ATTEMPTS: AtomicU64 = AtomicU64::new(0);
+static ACCEPTED: AtomicU64 = AtomicU64::new(0);
+static SKIPPED: AtomicU64 = AtomicU64::new(0);
+static REJECTED: AtomicU64 = AtomicU64::new(0);
+
+/// Lower `source` through S1->S2->S3 for supported Vapor compiles.
+pub(crate) fn lower_source_for_vapor(
+    allocator: &Allocator,
+    source: &str,
+    options: VaporS3BridgeOptions,
+) -> VaporS3BridgeStatus {
+    ATTEMPTS.fetch_add(1, Ordering::Relaxed);
+
+    if !options.is_supported() {
+        SKIPPED.fetch_add(1, Ordering::Relaxed);
+        return VaporS3BridgeStatus::Skipped;
+    }
+
+    let status = profile!("atelier.vapor.template.s3_bridge", {
+        let (tree, surface_errors) = vize_s1::parse_with_options(
+            allocator,
+            source,
+            SurfaceParseOptions {
+                experimental_in_tag_comments: options.experimental_in_tag_comments,
+            },
+        );
+        let s2 = vize_s1_to_s2::lower(allocator, &tree, &surface_errors);
+        let s3 = vize_s2_to_s3::lower(allocator, &s2.root);
+        let violations = verify(&s3.program);
+        if !violations.is_empty() {
+            let mut diagnostics = std::vec::Vec::new();
+            for violation in violations {
+                diagnostics.push(cstr!(
+                    "Davinci S3 verifier rejected Vapor bridge: {violation}"
+                ));
+            }
+            return_rejected(diagnostics)
+        } else if s3.partition.ops.len() != s3.program.ops.len() {
+            return_rejected(std::vec![cstr!(
+                "Davinci S3 verifier rejected Vapor bridge: partition facts {} did not match ops {}",
+                s3.partition.ops.len(),
+                s3.program.ops.len()
+            )])
+        } else {
+            let dynamic_ops = s3
+                .partition
+                .ops
+                .iter()
+                .filter(|fact| fact.kind.is_dynamic())
+                .count();
+            record_bridge_counters(
+                s3.program.ops.len() as u64,
+                dynamic_ops as u64,
+                s3.program.regions.len() as u64,
+                s3.program.effects.len() as u64,
+                s2.diagnostics.len() as u64,
+            );
+            VaporS3BridgeStatus::Accepted
+        }
+    });
+
+    if matches!(status, VaporS3BridgeStatus::Accepted) {
+        ACCEPTED.fetch_add(1, Ordering::Relaxed);
+    }
+
+    status
+}
+
+#[cfg(test)]
+pub(crate) fn stats() -> VaporS3BridgeStats {
+    VaporS3BridgeStats {
+        attempts: ATTEMPTS.load(Ordering::Relaxed),
+        accepted: ACCEPTED.load(Ordering::Relaxed),
+        skipped: SKIPPED.load(Ordering::Relaxed),
+        rejected: REJECTED.load(Ordering::Relaxed),
+    }
+}
+
+impl VaporS3BridgeOptions {
+    fn is_supported(self) -> bool {
+        !self.ssr
+            && !self.custom_renderer
+            && !self.experimental_patterned_template
+            && self.template_syntax == TemplateSyntaxMode::Standard
+            && !self.has_custom_elements
+    }
+}
+
+fn return_rejected(diagnostics: std::vec::Vec<String>) -> VaporS3BridgeStatus {
+    REJECTED.fetch_add(1, Ordering::Relaxed);
+    VaporS3BridgeStatus::Rejected(diagnostics)
+}
+
+fn record_bridge_counters(
+    ops: u64,
+    dynamic_ops: u64,
+    regions: u64,
+    effects: u64,
+    diagnostics: u64,
+) {
+    let profiler = global_profiler();
+    if !profiler.is_enabled() {
+        return;
+    }
+    profiler.record_counter_enabled("davinci.s3_vapor.files", 1);
+    profiler.record_counter_enabled("davinci.s3_vapor.ops", ops);
+    profiler.record_counter_enabled("davinci.s3_vapor.dynamic_ops", dynamic_ops);
+    profiler.record_counter_enabled("davinci.s3_vapor.regions", regions);
+    profiler.record_counter_enabled("davinci.s3_vapor.effects", effects);
+    profiler.record_counter_enabled("davinci.s3_vapor.s2_diagnostics", diagnostics);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{VaporS3BridgeOptions, VaporS3BridgeStatus, lower_source_for_vapor, stats};
+    use vize_atelier_core::TemplateSyntaxMode;
+    use vize_carton::Allocator;
+
+    fn supported_options() -> VaporS3BridgeOptions {
+        VaporS3BridgeOptions {
+            ssr: false,
+            custom_renderer: false,
+            experimental_in_tag_comments: false,
+            experimental_patterned_template: false,
+            template_syntax: TemplateSyntaxMode::Standard,
+            has_custom_elements: false,
+        }
+    }
+
+    #[test]
+    fn supported_templates_lower_to_verified_s3() {
+        let allocator = Allocator::new();
+        let before = stats();
+        let status = lower_source_for_vapor(
+            &allocator,
+            r#"<button :disabled="locked" @click="save">{{ label }}</button>"#,
+            supported_options(),
+        );
+        let after = stats();
+
+        assert!(matches!(status, VaporS3BridgeStatus::Accepted));
+        assert!(after.accepted > before.accepted);
+        assert_eq!(after.rejected, before.rejected);
+    }
+
+    #[test]
+    fn unsupported_vapor_options_skip_the_bridge() {
+        let allocator = Allocator::new();
+        let before = stats();
+        let status = lower_source_for_vapor(
+            &allocator,
+            r#"<x-thing />"#,
+            VaporS3BridgeOptions {
+                has_custom_elements: true,
+                ..supported_options()
+            },
+        );
+        let after = stats();
+
+        assert!(matches!(status, VaporS3BridgeStatus::Skipped));
+        assert!(after.skipped > before.skipped);
+    }
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |          1135 |                   786 |               349 |             158 |     373 |            1009 |      657 |           561 |           700 |
+| Compiler                   |          1142 |                   791 |               351 |             158 |     373 |            1013 |      660 |           562 |           701 |
 | Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           569 |
 | Typechecker                |           948 |                   260 |               688 |             427 |     214 |             881 |      708 |           512 |           731 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
@@ -61,10 +61,10 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          30 |              10 |       20 |
-| S0               |         949 |             498 |      451 |
-| S1               |           5 |               1 |        4 |
+| S0               |         951 |             499 |      452 |
+| S1               |           8 |               3 |        5 |
 | S2               |          41 |              21 |       20 |
-| S1->S2           |         110 |              13 |       97 |
+| S1->S2           |         112 |              14 |       98 |
 | old AST/parser   |          85 |              65 |       20 |
 | Croquis analysis |          73 |              57 |       16 |
 | raw OXC          |         373 |             344 |       29 |
@@ -79,7 +79,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | `crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs:6` | source   | S0 2<br>raw OXC 15                                                                                   |    17 |
 | `crates/vize_atelier_core/src/steps/expression/prefix.rs:6`                  | source   | S0 1<br>Croquis analysis 1<br>raw OXC 14                                                             |    16 |
 
-Additional source/manifest rows are in the TSV: 327 omitted.
+Additional source/manifest rows are in the TSV: 328 omitted.
 
 #### Top test/dev files
 
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 327 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 3<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 4 |    13 |
 
-Additional test/dev rows are in the TSV: 261 omitted.
+Additional test/dev rows are in the TSV: 262 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -924,13 +924,15 @@ compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/ssr_snapshot.rs	9	s0	S0
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/benches/davinci.rs	30	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	davinci	Davinci	stage	vize_davinci	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	s1	S1	stage	vize_s1	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/compile.rs	14	s0	S0	stage	vize_carton	compat	8
+compiler	Compiler	source	crates/vize_atelier_vapor/src/compile.rs	15	s0	S0	stage	vize_carton	compat	8
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate.rs	16	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context.rs	12	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -985,6 +987,11 @@ compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/component/s
 compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/deferred.rs	4	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/template.rs	8	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/text.rs	5	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_vapor/src/s3.rs	12	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/s3.rs	12	s1	S1	stage	vize_s1	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/s3.rs	66	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/s3.rs	66	s1	S1	stage	vize_s1	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/s3.rs	66	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/element.rs	5	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/slot.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/slot.rs	246	s0	S0	stage	vize_carton	compat	1

--- a/davinci-road/plan/phase-3-records/p3-6.md
+++ b/davinci-road/plan/phase-3-records/p3-6.md
@@ -22,7 +22,7 @@ duplicated directive transforms and prove TS-33 / TS-30 plus the bench floor.
 | -------------- | ------------------------------------------------------------------------------------------------ |
 | Bridge home    | `vize_atelier_vapor::s3` owns the production-path bridge so S3 remains backend-independent.      |
 | Failure mode   | S3 verifier failures become Vapor transform diagnostics; skipped unsupported options are silent. |
-| Counters       | Profiling records S3 file, op, dynamic-op, region, effect, and S2 diagnostic counts.            |
+| Counters       | Profiling records S3 file, op, dynamic-op, region, effect, and S2 diagnostic counts.             |
 | Payload policy | Existing Vapor IR remains the payload source until S3 gains typed generation payloads.           |
 
 ## Mechanical witnesses

--- a/davinci-road/plan/phase-3-records/p3-6.md
+++ b/davinci-road/plan/phase-3-records/p3-6.md
@@ -1,0 +1,35 @@
+# P3-6 - Vapor S3 bridge first slice
+
+This slice starts retargeting Vapor to S3 without claiming that the payload-rich
+legacy Vapor IR has been deleted. Supported Vapor compiles now build S1, lower
+S1 to S2, lower S2 to S3, verify the S3 artifact, and record profiler counters
+beside the existing Vapor IR generation. Unsupported option shapes stay on the
+legacy path until their S3 payload rules are explicit.
+
+## Boundary
+
+The bridge is selected for standard Vue 3 Vapor templates with no SSR mode, no
+custom renderer, no patterned-template desugaring, and no custom-element
+matcher. That matches the first payload-safe surface S3 currently models.
+
+This does not close P3-6. The remaining work is to move concrete Vapor payload
+construction from `lower/` onto the verified S3 artifact, then delete the
+duplicated directive transforms and prove TS-33 / TS-30 plus the bench floor.
+
+## Decisions
+
+| subject        | decision                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------ |
+| Bridge home    | `vize_atelier_vapor::s3` owns the production-path bridge so S3 remains backend-independent.      |
+| Failure mode   | S3 verifier failures become Vapor transform diagnostics; skipped unsupported options are silent. |
+| Counters       | Profiling records S3 file, op, dynamic-op, region, effect, and S2 diagnostic counts.            |
+| Payload policy | Existing Vapor IR remains the payload source until S3 gains typed generation payloads.           |
+
+## Mechanical witnesses
+
+- `cargo check -p vize_atelier_vapor`
+- `cargo test -p vize_atelier_vapor s3:: --lib`
+- `cargo test -p vize_atelier_vapor --lib`
+- `cargo clippy -p vize_atelier_vapor --lib -- -D warnings`
+- `node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-stage-release-firewall.test.ts tests/tooling/source-file-lengths.test.ts`
+- `git diff --check`

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -83,6 +83,10 @@ semantic context; deletes the run-then-discard double transform
 calls upstream `@vue/runtime-vapor` APIs only (charter #38). In-phase flag
 for fallback. _Accept:_ TS-33 behavioral parity; TS-30 traces; vapor bench
 improvement (the P0-3 double-transform number is the floor to beat).
+_First slice 2026-09-12:_ see
+[P3-6 record](./phase-3-records/p3-6.md) for the production-path S3 bridge,
+verified artifact guard, and profiler counters. The legacy Vapor IR payload
+lowering remains until S3 owns typed generation payloads.
 
 **P3-7 VDOM patch flags from facts.** `patch_flag.rs` inference replaced by
 lattice-fact consumption; flags become explicit S3 decisions (or S2→S4

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -255,6 +255,29 @@ test("Atelier core S2 witnesses import lowering through the physical S1-to-S2 pa
   }
 });
 
+test("Davinci Vapor compile path imports the verified S3 bridge", () => {
+  const vapor = workspacePackage(metadata, "vize_atelier_vapor");
+  for (const [dependencyName, rename] of [
+    ["vize_s1", null],
+    ["vize_s1_to_s2", null],
+    ["vize_s2_to_s3", null],
+    ["vize_impeto", "vize_s3"],
+  ] as const) {
+    const dep = dependency(metadata, "vize_atelier_vapor", dependencyName, null);
+    assert.equal(dep.rename, rename);
+    assert.equal(dep.req, `=${workspacePackage(metadata, dependencyName).version}`);
+  }
+
+  const compile = readRepoFile("crates", "vize_atelier_vapor", "src", "compile.rs");
+  const bridge = readRepoFile("crates", "vize_atelier_vapor", "src", "s3.rs");
+  assert.match(compile, /lower_source_for_vapor/u);
+  assert.match(bridge, /vize_s1::parse_with_options/u);
+  assert.match(bridge, /vize_s1_to_s2::lower/u);
+  assert.match(bridge, /vize_s2_to_s3::lower/u);
+  assert.match(bridge, /vize_s3::verify::verify/u);
+  assert.ok(vapor.dependencies.some((dep) => dep.name === "vize_s2_to_s3"));
+});
+
 const s0AliasConsumers = [
   ["vize", "vize package", ["crates", "vize"]],
   ["vize_test_runner", "Test runner", ["tests", "vize_test_runner"]],

--- a/tests/tooling/davinci-stage-release-firewall.test.ts
+++ b/tests/tooling/davinci-stage-release-firewall.test.ts
@@ -9,6 +9,7 @@ const publishedDavinciStages = new Set([
   "vize_s2",
   "vize_impeto",
   "vize_s1_to_s2",
+  "vize_s2_to_s3",
 ]);
 
 function isPublishable(pkg: Package): boolean {
@@ -109,6 +110,52 @@ test("DOM production keeps the published S2 renderer available for profiling", (
       // TypeScript templates are part of the public DOM compiler contract, so
       // the profiled DOM renderer enables the stage library's opt-in erasure.
       features: ["typescript"],
+    },
+  ]);
+});
+
+test("Vapor production selects only published stages for the S3 bridge", () => {
+  const stageEdges = workspacePackage(metadata, "vize_atelier_vapor")
+    .dependencies.filter(
+      (dependency) => dependency.kind === null && publishedDavinciStages.has(dependency.name),
+    )
+    .map((dependency) => ({
+      name: dependency.name,
+      req: dependency.req,
+      rename: dependency.rename,
+      optional: dependency.optional,
+      features: dependency.features,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  assert.deepEqual(stageEdges, [
+    {
+      name: "vize_impeto",
+      req: versionRequirement("vize_impeto"),
+      rename: "vize_s3",
+      optional: false,
+      features: [],
+    },
+    {
+      name: "vize_s1",
+      req: versionRequirement("vize_s1"),
+      rename: null,
+      optional: false,
+      features: [],
+    },
+    {
+      name: "vize_s1_to_s2",
+      req: versionRequirement("vize_s1_to_s2"),
+      rename: null,
+      optional: false,
+      features: [],
+    },
+    {
+      name: "vize_s2_to_s3",
+      req: versionRequirement("vize_s2_to_s3"),
+      rename: null,
+      optional: false,
+      features: [],
     },
   ]);
 });


### PR DESCRIPTION
## Summary
- add a production Vapor S3 bridge that builds and verifies S1 -> S2 -> S3 beside the existing Vapor IR path
- skip unsupported Vapor option shapes while surfacing S3 verifier failures as Vapor transform diagnostics
- add the P3-6 first-slice record plus dependency/release-firewall guards for the published stage crates

## Validation
- cargo check -p vize_atelier_vapor
- cargo test -p vize_atelier_vapor s3:: --lib
- cargo test -p vize_atelier_vapor --lib
- cargo clippy -p vize_atelier_vapor --lib -- -D warnings
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-stage-release-firewall.test.ts tests/tooling/source-file-lengths.test.ts
- git diff --check

Known local note: cargo clippy -p vize_atelier_vapor --all-targets -- -D warnings still hits existing test-target macro/style warnings outside this change; the new library path is clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791814871&installation_model_id=422833&pr_number=6066&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6066&signature=02b04e5cca75ae107f728b84fcb15e5ea47a54c0195e658f90eff1e17e67bb76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vapor compilation now validates generated output through the S3 pipeline for supported Vue 3 templates.
  * Unsupported template configurations continue using the existing compilation path.
  * Profiling counters are recorded for successful bridge operations.

* **Bug Fixes**
  * Invalid generated output now surfaces actionable diagnostics during compilation.

* **Documentation**
  * Added planning records describing the Vapor-to-S3 compilation bridge and supported scenarios.

* **Tests**
  * Added coverage for bridge integration and published dependency configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->