### PR TITLE
feat(davinci): split DOM patch facts

### DIFF
--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -86,6 +86,7 @@ mod once;
 mod options;
 mod outlet;
 mod outlet_props;
+mod patch;
 mod prefix;
 mod props;
 mod props_bind;

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -23,10 +23,10 @@ use super::create_slots;
 use super::directive;
 use super::flag::emit_patch_flag;
 use super::js::asset_ident;
-use super::props::{
-    BindPropsOptions, apply_static_ref_patch, bind_patch, emit_bind_props,
-    prune_legacy_patchless_dynamic_props,
+use super::patch::{
+    apply_static_ref_patch, binding_patch_facts, prune_legacy_patchless_dynamic_props,
 };
+use super::props::{BindPropsOptions, emit_bind_props};
 use super::props_dynamic::emit_dynamic_props;
 use super::props_static;
 use super::props_static::PropHoistPosition as Position;
@@ -166,7 +166,7 @@ pub(super) fn emit_call(
                 .clone(),
         );
     }
-    let mut patch = bind_patch(
+    let mut patch = binding_patch_facts(
         &component.bindings,
         true,
         if_key,

--- a/crates/vize_s1_to_s2/src/emit/merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/merge.rs
@@ -18,9 +18,10 @@ use super::EmitError;
 use super::UnsupportedReason as Reason;
 use super::buf::Buf;
 use super::on::{event_key_for, needs_hydration};
+use super::patch::PatchFacts;
 use super::prefix::Site;
 use super::props::{
-    BindName, Patch, PropsObjectOptions, StaticBindKeyCasing, bind_name, bind_value,
+    BindName, PropsObjectOptions, StaticBindKeyCasing, bind_name, bind_value,
     bind_value_is_static_patchless, emit_props_object, has_prop_modifier, is_emitted_key_bind,
     static_bind_key,
 };
@@ -63,7 +64,7 @@ pub(super) fn object_patch<'a>(
     constant_handler: &dyn Fn(&str) -> bool,
     handler_is_cached: &dyn Fn(&OnOp<'a>) -> bool,
     caches_handlers: bool,
-) -> Patch {
+) -> PatchFacts {
     let mut dynamic_props = StdVec::new();
     let mut flag = 16i32;
     for binding in bindings.iter() {
@@ -140,7 +141,7 @@ pub(super) fn object_patch<'a>(
             _ => {}
         }
     }
-    Patch {
+    PatchFacts {
         flag,
         dynamic_props,
     }

--- a/crates/vize_s1_to_s2/src/emit/patch.rs
+++ b/crates/vize_s1_to_s2/src/emit/patch.rs
@@ -1,0 +1,189 @@
+//! DOM patch-flag facts for VNode emission.
+//!
+//! P3-7 starts moving patch flags out of ad-hoc call construction and into a
+//! named fact surface. The current facts are still DOM-realization facts: they
+//! consume S2 binding ops, static-value classification, handler cache facts,
+//! and the emitter's position inputs, then the VNode writer only applies the
+//! few position-local masks (`v-for`, `v-once`, `v-memo`).
+
+use alloc::vec::Vec as StdVec;
+
+use vize_s0::String;
+use vize_s2::op::{Attribute, BindingOp, OnOp};
+
+use super::props::{
+    BindName, StaticBindKeyCasing, bind_name, bind_value_is_static_patchless,
+    bind_value_uses_legacy_patchless_runtime_expr, has_prop_modifier, is_dynamic_bind_name,
+    is_emitted_key_bind, static_bind_key,
+};
+
+pub(super) struct PatchFacts {
+    pub flag: i32,
+    pub dynamic_props: StdVec<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn binding_patch_facts<'a>(
+    bindings: &[BindingOp<'a>],
+    is_component: bool,
+    if_key: Option<&str>,
+    for_item: bool,
+    is_ts: bool,
+    constant_handler: &dyn Fn(&str) -> bool,
+    handler_is_cached: &dyn Fn(&OnOp<'a>) -> bool,
+    caches_handlers: bool,
+) -> PatchFacts {
+    if super::merge::has_object_spread(bindings) {
+        return super::merge::object_patch(
+            bindings,
+            is_component,
+            if_key,
+            for_item,
+            is_ts,
+            constant_handler,
+            handler_is_cached,
+            caches_handlers,
+        );
+    }
+    let mut flag = 0i32;
+    let mut dynamic_props = StdVec::new();
+    for binding in bindings.iter() {
+        match binding {
+            BindingOp::Bind(bind) => match bind_name(bind) {
+                _ if is_emitted_key_bind(bind, if_key) => {
+                    if for_item && is_dynamic_bind_name(bind) {
+                        flag |= 16;
+                    }
+                }
+                Ok(BindName::Static(raw_name)) => match raw_name {
+                    "ref" => flag |= 512,
+                    "class"
+                        if bind_value_is_static_patchless(bind, is_ts)
+                            || (!for_item
+                                && bind_value_uses_legacy_patchless_runtime_expr(bind)) => {}
+                    "class" if !is_component => flag |= 2,
+                    "style"
+                        if bind_value_is_static_patchless(bind, is_ts)
+                            || (!for_item
+                                && bind_value_uses_legacy_patchless_runtime_expr(bind)) => {}
+                    "style" if !is_component => flag |= 4,
+                    "key" => {}
+                    key if key.ends_with("Modifiers")
+                        || bind_value_is_static_patchless(bind, is_ts) => {}
+                    _ => {
+                        flag |= 8;
+                        let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+                            continue;
+                        };
+                        let owned = String::from(key.as_str());
+                        if !dynamic_props.contains(&owned) {
+                            dynamic_props.push(owned);
+                        }
+                        if has_prop_modifier(bind) {
+                            flag |= 32;
+                        }
+                    }
+                },
+                Ok(BindName::Dynamic(_)) => {
+                    flag |= 16;
+                    if has_prop_modifier(bind) {
+                        flag |= 32;
+                    }
+                }
+                Ok(BindName::Spread) | Err(_) => {}
+            },
+            BindingOp::On(on) => {
+                if super::on_dynamic::is_dynamic_on_name(on) {
+                    flag |= 16;
+                    continue;
+                }
+                let Ok(key) = super::on::event_key_for(on, !is_component) else {
+                    continue;
+                };
+                if !super::props::handler_is_constant(on, constant_handler)
+                    && !handler_is_cached(on)
+                {
+                    flag |= 8;
+                    if !dynamic_props.contains(&key) {
+                        dynamic_props.push(key.clone());
+                    }
+                }
+                if !is_component && super::on::needs_hydration(key.as_str(), on) {
+                    flag |= 32;
+                }
+            }
+            BindingOp::Model(model) => {
+                super::model::patch(
+                    model,
+                    is_component,
+                    &mut flag,
+                    &mut dynamic_props,
+                    caches_handlers,
+                );
+            }
+            BindingOp::VueHtml(_) => {
+                flag |= 8;
+                let key = String::from("innerHTML");
+                if !dynamic_props.contains(&key) {
+                    dynamic_props.push(key);
+                }
+            }
+            BindingOp::VueText(_) => {
+                flag |= 8;
+                let key = String::from("textContent");
+                if !dynamic_props.contains(&key) {
+                    dynamic_props.push(key);
+                }
+            }
+            _ => {}
+        }
+    }
+    // The shipped `NEED_PATCH` gate names `v-model` beside `v-show`, the
+    // custom directives and `ref`. Only a *cached* update handler reaches
+    // the difference: without caching the model always sets `PROPS`,
+    // which suppresses `NEED_PATCH` on both sides.
+    let has_model = bindings
+        .iter()
+        .any(|binding| matches!(binding, BindingOp::Model(_)));
+    if (super::directive::has_runtime(bindings) || has_model) && flag & (2 | 4 | 8 | 16) == 0 {
+        flag |= 512;
+    }
+    if flag & 16 != 0 {
+        flag &= !(2 | 4 | 8);
+    }
+    PatchFacts {
+        flag,
+        dynamic_props,
+    }
+}
+
+pub(super) fn prune_legacy_patchless_dynamic_props(
+    bindings: &[BindingOp<'_>],
+    dynamic_props: &mut StdVec<String>,
+) {
+    for binding in bindings.iter() {
+        let BindingOp::Bind(bind) = binding else {
+            continue;
+        };
+        if has_prop_modifier(bind) || !bind_value_uses_legacy_patchless_runtime_expr(bind) {
+            continue;
+        }
+        let Ok(BindName::Static(_)) = bind_name(bind) else {
+            continue;
+        };
+        let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+            continue;
+        };
+        dynamic_props.retain(|name| name.as_str() != key.as_str());
+    }
+}
+
+pub(super) fn apply_static_ref_patch(attributes: &[Attribute<'_>], flag: &mut i32) {
+    let has_static_ref = attributes.iter().any(|attr| attr.name == "ref");
+    // The shipped gate is the *normal prop* flags alone: NEED_PATCH still
+    // combines with TEXT and NEED_HYDRATION, because neither of those updates
+    // a ref on its own.
+    if has_static_ref && *flag & (2 | 4 | 8 | 16) == 0 {
+        *flag |= 512;
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -4,19 +4,16 @@ mod constness;
 mod static_expr;
 mod ts_view;
 
-use alloc::vec::Vec as StdVec;
-
-use vize_s0::String;
-use vize_s2::op::{Attribute, BindingOp, OnOp};
+use vize_s2::op::{Attribute, BindingOp};
 
 use super::EmitCx;
 use super::EmitError;
 use super::UnsupportedReason as Reason;
 use super::buf::Buf;
-use super::on::{admit_on, event_key_for, needs_hydration};
+use super::on::admit_on;
 pub(in crate::emit) use constness::handler_is_constant;
 pub(super) use constness::{bind_value_is_static_patchless, bind_value_text};
-use static_expr::bind_value_uses_legacy_patchless_runtime_expr;
+pub(super) use static_expr::bind_value_uses_legacy_patchless_runtime_expr;
 
 pub(super) use super::props_bind::{
     BindName, StaticBindKeyCasing, bind_name, emit_dynamic_bind_pair, has_prop_modifier,
@@ -24,11 +21,6 @@ pub(super) use super::props_bind::{
 };
 pub(super) use super::props_object::{Piece, PropsObjectOptions, emit_props_object, pieces};
 pub(super) use super::props_value::bind_value;
-
-pub(super) struct Patch {
-    pub flag: i32,
-    pub dynamic_props: StdVec<String>,
-}
 
 #[derive(Clone, Copy, Default)]
 pub(super) struct BindPropsOptions<'a> {
@@ -103,160 +95,6 @@ fn admit_bindings_inner(bindings: &[BindingOp<'_>], allow_once: bool) -> Result<
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(super) fn bind_patch<'a>(
-    bindings: &[BindingOp<'a>],
-    is_component: bool,
-    if_key: Option<&str>,
-    for_item: bool,
-    is_ts: bool,
-    constant_handler: &dyn Fn(&str) -> bool,
-    handler_is_cached: &dyn Fn(&OnOp<'a>) -> bool,
-    caches_handlers: bool,
-) -> Patch {
-    if super::merge::has_object_spread(bindings) {
-        return super::merge::object_patch(
-            bindings,
-            is_component,
-            if_key,
-            for_item,
-            is_ts,
-            constant_handler,
-            handler_is_cached,
-            caches_handlers,
-        );
-    }
-    let mut flag = 0i32;
-    let mut dynamic_props = StdVec::new();
-    for binding in bindings.iter() {
-        match binding {
-            BindingOp::Bind(bind) => match bind_name(bind) {
-                _ if is_emitted_key_bind(bind, if_key) => {
-                    if for_item && is_dynamic_bind_name(bind) {
-                        flag |= 16;
-                    }
-                }
-                Ok(BindName::Static(raw_name)) => match raw_name {
-                    "ref" => flag |= 512,
-                    "class"
-                        if bind_value_is_static_patchless(bind, is_ts)
-                            || (!for_item
-                                && bind_value_uses_legacy_patchless_runtime_expr(bind)) => {}
-                    "class" if !is_component => flag |= 2,
-                    "style"
-                        if bind_value_is_static_patchless(bind, is_ts)
-                            || (!for_item
-                                && bind_value_uses_legacy_patchless_runtime_expr(bind)) => {}
-                    "style" if !is_component => flag |= 4,
-                    "key" => {}
-                    key if key.ends_with("Modifiers")
-                        || bind_value_is_static_patchless(bind, is_ts) => {}
-                    _ => {
-                        flag |= 8;
-                        let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
-                            continue;
-                        };
-                        let owned = String::from(key.as_str());
-                        if !dynamic_props.contains(&owned) {
-                            dynamic_props.push(owned);
-                        }
-                        if has_prop_modifier(bind) {
-                            flag |= 32;
-                        }
-                    }
-                },
-                Ok(BindName::Dynamic(_)) => {
-                    flag |= 16;
-                    if has_prop_modifier(bind) {
-                        flag |= 32;
-                    }
-                }
-                Ok(BindName::Spread) | Err(_) => {}
-            },
-            BindingOp::On(on) => {
-                if super::on_dynamic::is_dynamic_on_name(on) {
-                    flag |= 16;
-                    continue;
-                }
-                let Ok(key) = event_key_for(on, !is_component) else {
-                    continue;
-                };
-                if !handler_is_constant(on, constant_handler) && !handler_is_cached(on) {
-                    flag |= 8;
-                    if !dynamic_props.contains(&key) {
-                        dynamic_props.push(key.clone());
-                    }
-                }
-                if !is_component && needs_hydration(key.as_str(), on) {
-                    flag |= 32;
-                }
-            }
-            BindingOp::Model(model) => {
-                super::model::patch(
-                    model,
-                    is_component,
-                    &mut flag,
-                    &mut dynamic_props,
-                    caches_handlers,
-                );
-            }
-            BindingOp::VueHtml(_) => {
-                flag |= 8;
-                let key = String::from("innerHTML");
-                if !dynamic_props.contains(&key) {
-                    dynamic_props.push(key);
-                }
-            }
-            BindingOp::VueText(_) => {
-                flag |= 8;
-                let key = String::from("textContent");
-                if !dynamic_props.contains(&key) {
-                    dynamic_props.push(key);
-                }
-            }
-            _ => {}
-        }
-    }
-    // The shipped `NEED_PATCH` gate names `v-model` beside `v-show`, the
-    // custom directives and `ref`. Only a *cached* update handler reaches
-    // the difference: without caching the model always sets `PROPS`,
-    // which suppresses `NEED_PATCH` on both sides.
-    let has_model = bindings
-        .iter()
-        .any(|binding| matches!(binding, BindingOp::Model(_)));
-    if (super::directive::has_runtime(bindings) || has_model) && flag & (2 | 4 | 8 | 16) == 0 {
-        flag |= 512;
-    }
-    if flag & 16 != 0 {
-        flag &= !(2 | 4 | 8);
-    }
-    Patch {
-        flag,
-        dynamic_props,
-    }
-}
-
-pub(super) fn prune_legacy_patchless_dynamic_props(
-    bindings: &[BindingOp<'_>],
-    dynamic_props: &mut StdVec<String>,
-) {
-    for binding in bindings.iter() {
-        let BindingOp::Bind(bind) = binding else {
-            continue;
-        };
-        if has_prop_modifier(bind) || !bind_value_uses_legacy_patchless_runtime_expr(bind) {
-            continue;
-        }
-        let Ok(BindName::Static(_)) = bind_name(bind) else {
-            continue;
-        };
-        let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
-            continue;
-        };
-        dynamic_props.retain(|name| name.as_str() != key.as_str());
-    }
-}
-
 pub(super) fn emit_bind_props(
     cx: &mut EmitCx<'_>,
     attributes: &[Attribute<'_>],
@@ -308,18 +146,6 @@ pub(super) fn emit_bind_props(
         cx.buf.push(")");
     }
     Ok(())
-}
-
-pub(super) fn apply_static_ref_patch(attributes: &[Attribute<'_>], flag: &mut i32) {
-    let has_static_ref = attributes.iter().any(|attr| attr.name == "ref");
-    // The shipped gate is the *normal prop* flags alone: NEED_PATCH still
-    // combines with TEXT and NEED_HYDRATION, because neither of those
-    // updates a ref on its own. Only an inlined render function reaches
-    // the difference — elsewhere a handler that sets NEED_HYDRATION is
-    // dynamic and sets PROPS with it.
-    if has_static_ref && *flag & (2 | 4 | 8 | 16) == 0 {
-        *flag |= 512;
-    }
 }
 
 fn has_dynamic_bind_name(bindings: &[BindingOp<'_>], if_key: Option<&str>) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
+++ b/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
@@ -5,7 +5,7 @@ use vize_s2::op::BindOp;
 
 use super::bind_value;
 
-pub(super) fn bind_value_uses_legacy_patchless_runtime_expr(bind: &BindOp<'_>) -> bool {
+pub(in crate::emit) fn bind_value_uses_legacy_patchless_runtime_expr(bind: &BindOp<'_>) -> bool {
     match bind_value(bind) {
         Ok(value) => value
             .js()

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -16,9 +16,8 @@ use super::children::children_need_text_flag;
 use super::directive;
 use super::flag::emit_patch_flag;
 use super::namespace;
-use super::props::{
-    BindPropsOptions, admit_element_bindings, apply_static_ref_patch, bind_patch, emit_bind_props,
-};
+use super::patch::{apply_static_ref_patch, binding_patch_facts};
+use super::props::{BindPropsOptions, admit_element_bindings, emit_bind_props};
 use super::props_dynamic::emit_dynamic_props;
 use super::props_static::PropHoistPosition;
 use super::vnode_children::emit_children;
@@ -238,7 +237,7 @@ pub(super) fn emit_call(
             None
         };
     let hoist = hoisted_props.is_some();
-    let patch = bind_patch(
+    let patch = binding_patch_facts(
         &element.bindings,
         false,
         if_key,

--- a/davinci-road/plan/phase-3-records/p3-7.md
+++ b/davinci-road/plan/phase-3-records/p3-7.md
@@ -1,0 +1,43 @@
+# P3-7 - VDOM patch facts first slice
+
+This slice starts replacing VDOM patch-flag inference with an explicit DOM
+realization fact surface while keeping shipped DOM output byte-identical.
+
+## Boundary
+
+The slice chooses the S2 to S4 annotation route for now. Current S3 records the
+canonical op graph and static/dynamic partition, but it does not yet carry the
+typed binding payloads that Vue patch flags need: static bind keys, modifier
+realization, cached-handler state, component fallthrough props, and legacy
+patchless runtime expressions. Sending DOM through S3 here would either lose
+those inputs or re-derive them later, which is exactly the P3-7 problem.
+
+This does not close P3-7. The remaining work is to materialize the owner-keyed
+patch facts before VNode emission, connect them to the reactivity-lattice facts
+where binding metadata is available, and re-gate the DOM corpus.
+
+## Decisions
+
+| subject       | decision                                                                                              |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| Fact home     | `vize_s1_to_s2::emit::patch` owns `PatchFacts` instead of leaving the decision inside props emission. |
+| Compatibility | Existing `vize_atelier_core::codegen::patch_flag` remains only for compatibility fallback lanes.      |
+| Data carried  | `PatchFacts` carries the numeric flag plus the dynamic-prop key list in source order.                 |
+| Local masks   | `v-for`, `v-once`, `v-memo`, static refs, dynamic slots, and text-child flags stay at VNode position. |
+| Parity rule   | The broad patch-flag fixtures still compare S2 DOM output against the shipped compatibility lane.     |
+
+## Mechanical witnesses
+
+- `cargo check -p vize_s1_to_s2 -p vize_atelier_dom`
+- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture`
+- `cargo test -p vize_atelier_dom --test davinci_s2_recent_patch_flags -- --nocapture`
+- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_static -- --nocapture`
+- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_legacy --features legacy -- --nocapture`
+
+## Follow-up
+
+P3-7 still needs a pre-emission side table that keys `PatchFacts` by owner
+`NodeId`, plus DOM corpus TS-11 and patch-flag equivalence fixtures over the
+materialized table. Once S3 has typed binding payloads, this fact surface can
+move from S2 to the explicit S3 decision stream without changing the VNode
+writer again.

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -92,6 +92,10 @@ lowering remains until S3 owns typed generation payloads.
 lattice-fact consumption; flags become explicit S3 decisions (or S2→S4
 annotations if S3 detour measures badly — decide by TS-22). _Accept:_ corpus
 DOM byte-parity (TS-11 empty); patch-flag equivalence fixtures.
+_First slice 2026-09-13:_ see
+[P3-7 record](./phase-3-records/p3-7.md) for the S2→S4 annotation boundary and
+the initial `PatchFacts` split. The owner-keyed fact table and corpus gate
+remain before this task closes.
 
 **P3-8 SSR thin path.** S2→S4 string-plan lowering reading partition facts;
 `vize_atelier_ssr` codegen re-targets. _Accept:_ SSR corpus byte-parity

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -76,6 +76,7 @@ s1_to_s2	-	crates/vize_s1_to_s2/src/emit/model_key.rs	0	0	1	8	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/on.rs	0	0	1	5	0	0	1	3
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/on_dynamic.rs	1	5	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/options.rs	1	4	1	8	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/patch.rs	1	3	1	5	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix.rs	0	0	1	11	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix/aliases.rs	0	0	1	8	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/prefix/codegen_visitor.rs	1	9	1	11	0	0	0	0
@@ -88,7 +89,6 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/prefix/slot_defaults.rs	1	7	1	8	0	0	
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/prefix/splice.rs	1	4	1	12	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix/strip.rs	0	0	1	7	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix/typescript.rs	0	0	1	11	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props.rs	1	3	1	5	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props/constness.rs	0	0	1	2	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props/ts_view.rs	0	0	1	3	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_bind.rs	1	5	1	2	0	0	0	0


### PR DESCRIPTION
## Summary
- Split DOM patch flag and dynamic-prop key selection into `emit::patch::PatchFacts`.
- Keep element and component VNode emitters consuming those facts while preserving local position masks.
- Record the P3-7 first slice, S2 to S4 annotation boundary, remaining owner-keyed table/corpus gate, and reviewed storage inventory move.

## Tests
- `cargo check -p vize_s1_to_s2 -p vize_atelier_dom`
- `cargo clippy -p vize_s1_to_s2 -p vize_atelier_dom -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_s1_to_s2 --tests -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_recent_patch_flags -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_static -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_legacy --features legacy -- --nocapture`
- `node --test tests/tooling/davinci-matrices.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-consumer-migration-surfaces-check.test.mjs`
- `node --test tests/tooling/davinci-storage-policy.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 8`
- `git diff --check`