### PR TITLE
test(davinci): pin source map coverage budgets

### DIFF
--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -302,6 +302,16 @@ wall_time = "report-only"
 # Minimum coverage per backend and mapping category. Populated before P3-9
 # merges; deletion of the legacy recovery requires new-path coverage >= the
 # old heuristic's measured coverage.
+dom_static_template = { backend = "dom", category = "static-template", anchors_min = 6, coverage_pct_min = 95, span_accuracy_pct_min = 100 }
+dom_rewritten_identifier = { backend = "dom", category = "rewritten-identifier", anchors_min = 7, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
+dom_section_boundary = { backend = "dom", category = "section-boundary", anchors_min = 3, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
+vapor_static_template = { backend = "vapor", category = "static-template", anchors_min = 6, coverage_pct_min = 95, span_accuracy_pct_min = 100 }
+vapor_rewritten_identifier = { backend = "vapor", category = "rewritten-identifier", anchors_min = 7, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
+vapor_section_boundary = { backend = "vapor", category = "section-boundary", anchors_min = 3, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
+ssr_static_template = { backend = "ssr", category = "static-template", anchors_min = 6, coverage_pct_min = 95, span_accuracy_pct_min = 100 }
+ssr_rewritten_identifier = { backend = "ssr", category = "rewritten-identifier", anchors_min = 7, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
+ssr_section_boundary = { backend = "ssr", category = "section-boundary", anchors_min = 3, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
+legacy_sfc_text_matching_recovery = { backend = "legacy-sfc", category = "text-matching-recovery", anchors_min = 7, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
 
 [resource]
 # Resident-tier ceilings: rss_peak_bytes per machine preset, cold_start_ms,

--- a/davinci-road/plan/phase-3-records/p3-9.md
+++ b/davinci-road/plan/phase-3-records/p3-9.md
@@ -7,11 +7,11 @@ This slice establishes the numeric gate before changing emitters.
 `davinci-road/plan/budgets.toml` now carries `[sourcemap]` rows for the
 required P3-9 backend/category matrix:
 
-| Backend | Categories |
-| --- | --- |
-| DOM | `static-template`, `rewritten-identifier`, `section-boundary` |
-| Vapor | `static-template`, `rewritten-identifier`, `section-boundary` |
-| SSR | `static-template`, `rewritten-identifier`, `section-boundary` |
+| Backend | Categories                                                    |
+| ------- | ------------------------------------------------------------- |
+| DOM     | `static-template`, `rewritten-identifier`, `section-boundary` |
+| Vapor   | `static-template`, `rewritten-identifier`, `section-boundary` |
+| SSR     | `static-template`, `rewritten-identifier`, `section-boundary` |
 
 Each row pins a minimum authored-anchor count, a minimum coverage percentage,
 and an exact span-accuracy floor. Rewritten identifiers stay at 100% coverage

--- a/davinci-road/plan/phase-3-records/p3-9.md
+++ b/davinci-road/plan/phase-3-records/p3-9.md
@@ -1,0 +1,27 @@
+# P3-9 — S4 Structured Emitter + Universal Source Maps
+
+## Slice 1: TS-31 Budget Pin
+
+This slice establishes the numeric gate before changing emitters.
+
+`davinci-road/plan/budgets.toml` now carries `[sourcemap]` rows for the
+required P3-9 backend/category matrix:
+
+| Backend | Categories |
+| --- | --- |
+| DOM | `static-template`, `rewritten-identifier`, `section-boundary` |
+| Vapor | `static-template`, `rewritten-identifier`, `section-boundary` |
+| SSR | `static-template`, `rewritten-identifier`, `section-boundary` |
+
+Each row pins a minimum authored-anchor count, a minimum coverage percentage,
+and an exact span-accuracy floor. Rewritten identifiers stay at 100% coverage
+and 100% span accuracy because TS-31 calls them out as exact assertions.
+
+The legacy SFC text-matching source-map recovery is also recorded as
+`legacy_sfc_text_matching_recovery`, so deleting
+`crates/vize_atelier_sfc/src/source_map.rs` has a visible floor: a future S4
+path must show coverage at least as good as this legacy row before removal.
+
+The checker lives in `tests/tooling/davinci-sourcemap-budgets.test.ts`; it
+keeps `[sourcemap]` non-empty, verifies every DOM/Vapor/SSR category cell, and
+rejects malformed or non-numeric budget rows.

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -14,7 +14,7 @@
 - [ ] P3-6 Vapor backend on S3
 - [ ] P3-7 VDOM patch flags from lattice facts
 - [ ] P3-8 SSR thin path
-- [ ] P3-9 S4 structured emitter + universal source maps
+- [ ] P3-9 S4 structured emitter + universal source maps _(slice 1 pins TS-31 source-map budgets before emitter migration; see [record](./phase-3-records/p3-9.md))_
 - [ ] P3-10 Try-measure-commit extraction
 - [ ] P3-11 IVM oracle
 - [ ] P3-12 Behavioral (sprout) runner incl. IME scripts

--- a/tests/tooling/davinci-sourcemap-budgets.test.ts
+++ b/tests/tooling/davinci-sourcemap-budgets.test.ts
@@ -1,0 +1,123 @@
+// Davinci source-map budgets (plan/phase-3.md P3-9).
+//
+// P3-9 replaces string appends with structured, span-carrying emission across
+// DOM, Vapor and SSR. This test pins the numeric coverage contract before the
+// emitter work lands, and keeps the legacy SFC text-matching recovery visible
+// as the deletion floor.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { parseTomlLite } from "../../legacy-tools/davinci/toml-lite.mjs";
+
+type SourceMapBudget = {
+  backend: string;
+  category: string;
+  anchors_min: number;
+  coverage_pct_min: number;
+  span_accuracy_pct_min: number;
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const budgetsPath = path.join(repoRoot, "davinci-road", "plan", "budgets.toml");
+const budgetsText = fs.readFileSync(budgetsPath, "utf8");
+const budgets = parseTomlLite(budgetsText) as {
+  sourcemap: Record<string, SourceMapBudget>;
+};
+
+const REQUIRED_BACKENDS = ["dom", "vapor", "ssr"] as const;
+const REQUIRED_CATEGORIES = [
+  "static-template",
+  "rewritten-identifier",
+  "section-boundary",
+] as const;
+
+function inlineTableLines(section: string): string[] {
+  const lines = budgetsText.split("\n");
+  const start = lines.indexOf(`[${section}]`);
+  assert.ok(start >= 0, `budgets.toml must declare a [${section}] section`);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith("["));
+  const body = end === -1 ? rest : rest.slice(0, end);
+  return body.filter((line) => /^[A-Za-z0-9._-]+ = \{/.test(line));
+}
+
+function assertPercent(value: unknown, field: string, id: string): asserts value is number {
+  assert.ok(
+    Number.isSafeInteger(value) && value >= 0 && value <= 100,
+    `[sourcemap.${id}] ${field} must be a 0..100 integer, got ${String(value)}`,
+  );
+}
+
+test("source-map budgets cover every P3-9 backend/category cell", () => {
+  const entries = Object.entries(budgets.sourcemap);
+  assert.ok(entries.length > 0, "budgets.toml [sourcemap] must not be empty for P3-9");
+
+  const requiredCells = new Set(
+    REQUIRED_BACKENDS.flatMap((backend) =>
+      REQUIRED_CATEGORIES.map((category) => `${backend}/${category}`),
+    ),
+  );
+  const seenCells = new Set<string>();
+  const legacyRows: string[] = [];
+
+  for (const [id, entry] of entries) {
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      ["anchors_min", "backend", "category", "coverage_pct_min", "span_accuracy_pct_min"],
+      `[sourcemap.${id}] must keep the documented field set`,
+    );
+    assert.ok(Number.isSafeInteger(entry.anchors_min) && entry.anchors_min > 0);
+    assertPercent(entry.coverage_pct_min, "coverage_pct_min", id);
+    assertPercent(entry.span_accuracy_pct_min, "span_accuracy_pct_min", id);
+
+    if (entry.backend === "legacy-sfc") {
+      legacyRows.push(`${id}/${entry.category}`);
+      continue;
+    }
+
+    assert.ok(
+      (REQUIRED_BACKENDS as readonly string[]).includes(entry.backend),
+      `[sourcemap.${id}] backend ${entry.backend} is not a P3-9 backend`,
+    );
+    assert.ok(
+      (REQUIRED_CATEGORIES as readonly string[]).includes(entry.category),
+      `[sourcemap.${id}] category ${entry.category} is not a required P3-9 category`,
+    );
+    const cell = `${entry.backend}/${entry.category}`;
+    assert.ok(!seenCells.has(cell), `duplicate source-map budget cell ${cell}`);
+    seenCells.add(cell);
+  }
+
+  const missingCells = [...requiredCells].filter((cell) => !seenCells.has(cell)).sort();
+  assert.deepEqual(missingCells, [], "P3-9 must pin every backend/category cell");
+  assert.deepEqual(legacyRows, ["legacy_sfc_text_matching_recovery/text-matching-recovery"]);
+});
+
+test("source-map budget entries are one-line inline tables with real thresholds", () => {
+  const entryLines = inlineTableLines("sourcemap");
+  assert.equal(entryLines.length, Object.keys(budgets.sourcemap).length);
+  for (const line of entryLines) {
+    assert.match(
+      line,
+      /^[A-Za-z0-9._-]+ = \{ backend = "[a-z-]+", category = "[a-z-]+", anchors_min = [1-9]\d*, coverage_pct_min = \d+, span_accuracy_pct_min = \d+ \}$/,
+      `sourcemap entries must keep the canonical field order and spacing:\n${line}`,
+    );
+  }
+});
+
+test("rewritten identifiers and legacy recovery keep exact span accuracy floors", () => {
+  for (const [id, entry] of Object.entries(budgets.sourcemap)) {
+    if (entry.category === "rewritten-identifier" || entry.backend === "legacy-sfc") {
+      assert.equal(
+        entry.coverage_pct_min,
+        100,
+        `[sourcemap.${id}] must keep full coverage until P3-9 records a reviewed floor`,
+      );
+      assert.equal(entry.span_accuracy_pct_min, 100);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- populate the P3-9 `[sourcemap]` budget matrix for DOM, Vapor, and SSR
- add a tooling guard that requires every backend/category cell and exact rewritten-identifier span floors
- record the legacy SFC text-matching recovery as the deletion floor before the universal S4 emitter migration

## Validation
- `node --test tests/tooling/davinci-sourcemap-budgets.test.ts tests/tooling/davinci-budgets.test.ts tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD~1..HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791844852&installation_model_id=422833&pr_number=6071&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6071&signature=970304dd230894c073a043b94cd917323d0a6674c71b56c2c094c3e5cd62acbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-map coverage budgets for DOM, Vapor, SSR, and legacy SFC scenarios.
  * Established minimum requirements for authored anchors, coverage, and span accuracy, including full accuracy for rewritten identifiers.

* **Tests**
  * Added validation for required budget entries, valid thresholds, documented formatting, and legacy source-map recovery requirements.

* **Documentation**
  * Documented the P3-9 source-map budget plan and linked it from the phase roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->