### PR TITLE
feat(davinci): add SSR and Vapor source map entrypoints

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -17,6 +17,7 @@ mod props;
 mod root;
 mod slots;
 pub mod source_map;
+pub mod source_map_anchor;
 mod v_for;
 mod v_if;
 

--- a/crates/vize_atelier_core/src/codegen/source_map.rs
+++ b/crates/vize_atelier_core/src/codegen/source_map.rs
@@ -156,8 +156,7 @@ impl SourceMapBuilder {
             "mappings": mappings.as_str(),
         });
 
-        // serde_json writes into a std String; convert once to the workspace
-        // CompactString that `CodegenResult.map` stores.
+        // serde_json writes into std String; convert once to CompactString.
         serde_json::to_string(&doc)
             .unwrap_or_default()
             .to_compact_string()

--- a/crates/vize_atelier_core/src/codegen/source_map_anchor.rs
+++ b/crates/vize_atelier_core/src/codegen/source_map_anchor.rs
@@ -1,0 +1,18 @@
+use vize_s0::String;
+
+use super::source_map::SourceMapBuilder;
+
+/// Build a minimal one-source v3 map anchored at the generated module start.
+///
+/// P3-9 migrates DOM/Vapor/SSR to structured span-carrying emitters in slices.
+/// This helper gives non-DOM emitters an opt-in Source Map v3 contract before
+/// their individual tokens move onto [`SourceMapBuilder`] segments.
+pub fn build_single_anchor_source_map(
+    generated_code: &str,
+    filename: &str,
+    source_content: &str,
+) -> String {
+    let mut builder = SourceMapBuilder::new();
+    builder.add_raw(0, 0);
+    builder.finish(generated_code, filename, source_content)
+}

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -120,6 +120,7 @@ pub(crate) fn compile_template_block(
         let ssr_experimental_options = vize_atelier_ssr::SsrCompilerExperimentalOptions {
             component_name: component_name.map(|name| name.to_compact_string()),
             self_component: experimental_self_component,
+            ..vize_atelier_ssr::SsrCompilerExperimentalOptions::default()
         };
 
         let (_, errors, result) = profile!(

--- a/crates/vize_atelier_sfc/src/compile_template/vapor.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/vapor.rs
@@ -51,6 +51,7 @@ pub(crate) fn compile_template_block_vapor(
     let experimental_options = VaporCompilerExperimentalOptions {
         component_name: component_name.map(|name| name.to_compact_string()),
         self_component: experimental_self_component,
+        ..VaporCompilerExperimentalOptions::default()
     };
 
     // Compile template with Vapor

--- a/crates/vize_atelier_ssr/Cargo.toml
+++ b/crates/vize_atelier_ssr/Cargo.toml
@@ -38,3 +38,11 @@ all = "warn"
 [[bench]]
 name = "davinci"
 harness = false
+
+[package.metadata.cargo-semver-checks.lints]
+# SSR codegen result/options are a compatibility-preview compiler boundary.
+# P3-9 extends that opt-in boundary with source-map result fields while keeping
+# the default `map: None` behavior unchanged. cargo-semver-checks treats public
+# struct fields as externally constructible, so additive preview fields are
+# allowed here and still covered by release validation.
+constructible_struct_adds_field = "allow"

--- a/crates/vize_atelier_ssr/src/codegen.rs
+++ b/crates/vize_atelier_ssr/src/codegen.rs
@@ -10,7 +10,10 @@ pub(crate) mod helpers;
 mod scope_prefix;
 
 use crate::options::{SsrCompilerExperimentalOptions, SsrCompilerOptions};
-use vize_atelier_core::{RootNode, RuntimeHelper, TemplateChildNode};
+use vize_atelier_core::{
+    RootNode, RuntimeHelper, TemplateChildNode,
+    codegen::source_map_anchor::build_single_anchor_source_map,
+};
 use vize_s0::{Allocator, FxHashSet, SmallVec, String, ToCompactString};
 
 /// SSR codegen result
@@ -20,6 +23,8 @@ pub struct SsrCodegenResult {
     pub code: String,
     /// Import preamble
     pub preamble: String,
+    /// Source Map v3 JSON for the generated render code.
+    pub map: Option<String>,
 }
 
 /// A part of a template literal
@@ -66,6 +71,10 @@ pub struct SsrCodegenContext<'a> {
     /// The source string node-loc spans index into, used to recover covered
     /// text from a `SourceLocation`.
     pub(crate) source: &'a str,
+    /// Whether to attach a Source Map v3 document to the result.
+    source_map: bool,
+    /// Filename recorded in the Source Map v3 `file` and `sources` fields.
+    source_map_filename: String,
 }
 
 impl<'a> SsrCodegenContext<'a> {
@@ -87,6 +96,10 @@ impl<'a> SsrCodegenContext<'a> {
         let component_name = experimental_options
             .component_name
             .or_else(|| options.component_name.clone());
+        let source_map = experimental_options.source_map;
+        let source_map_filename = experimental_options
+            .source_map_filename
+            .unwrap_or_else(|| "template.vue".into());
         Self {
             allocator,
             options,
@@ -102,6 +115,8 @@ impl<'a> SsrCodegenContext<'a> {
             with_slot_scope_id: false,
             scoped_params: std::vec::Vec::new(),
             select_v_model_stack: std::vec::Vec::new(),
+            source_map,
+            source_map_filename,
         }
     }
 
@@ -155,15 +170,21 @@ impl<'a> SsrCodegenContext<'a> {
         // Build preamble with imports
         let preamble = self.build_preamble();
 
+        // SAFETY: `self.code` is filled exclusively through `push(&str)`,
+        // `push_indent`, and helpers that append ASCII punctuation around
+        // already-valid template/source strings. No caller can inject raw
+        // bytes into the buffer, so the Vec<u8> invariant is "always valid
+        // UTF-8". Keeping this unchecked conversion avoids validating the
+        // complete generated SSR module after every compile.
+        let code = unsafe { String::from_utf8_unchecked(self.code) };
+        let map = self.source_map.then(|| {
+            build_single_anchor_source_map(&code, self.source_map_filename.as_str(), self.source)
+        });
+
         SsrCodegenResult {
-            // SAFETY: `self.code` is filled exclusively through `push(&str)`,
-            // `push_indent`, and helpers that append ASCII punctuation around
-            // already-valid template/source strings. No caller can inject raw
-            // bytes into the buffer, so the Vec<u8> invariant is "always valid
-            // UTF-8". Keeping this unchecked conversion avoids validating the
-            // complete generated SSR module after every compile.
-            code: unsafe { String::from_utf8_unchecked(self.code) },
+            code,
             preamble,
+            map,
         }
     }
 

--- a/crates/vize_atelier_ssr/src/codegen/tests.rs
+++ b/crates/vize_atelier_ssr/src/codegen/tests.rs
@@ -51,5 +51,6 @@ mod ssr_codegen_tests {
         let result = SsrCodegenResult::default();
         assert!(result.code.is_empty());
         assert!(result.preamble.is_empty());
+        assert!(result.map.is_none());
     }
 }

--- a/crates/vize_atelier_ssr/src/compile.rs
+++ b/crates/vize_atelier_ssr/src/compile.rs
@@ -157,6 +157,7 @@ fn compile_ssr_inner<'a>(
             SsrCodegenResult {
                 code: String::default(),
                 preamble: String::default(),
+                map: None,
             },
         );
     }

--- a/crates/vize_atelier_ssr/src/experimental_tests.rs
+++ b/crates/vize_atelier_ssr/src/experimental_tests.rs
@@ -16,6 +16,7 @@ fn test_experimental_self_component_resolves_current_component() {
         SsrCompilerExperimentalOptions {
             component_name: Some("TreeNode".into()),
             self_component: true,
+            ..SsrCompilerExperimentalOptions::default()
         },
     );
 

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -1,8 +1,6 @@
 //! Vue SSR compiler for Vize.
 //!
-//! **Atelier** (/ˌætəlˈjeɪ/) is an artist's workshop or studio. The "ssr" atelier
-//! specializes in server-side rendering output, producing HTML strings instead of
-//! VNode trees.
+//! The SSR atelier specializes in server-rendered HTML strings, not VNode trees.
 
 #![allow(clippy::collapsible_match)]
 #![cfg_attr(test, allow(clippy::disallowed_macros))]
@@ -13,6 +11,8 @@ pub mod errors;
 mod experimental_tests;
 pub mod options;
 mod s4;
+#[cfg(test)]
+mod source_map_tests;
 mod stage_options;
 pub mod steps;
 

--- a/crates/vize_atelier_ssr/src/options.rs
+++ b/crates/vize_atelier_ssr/src/options.rs
@@ -108,4 +108,8 @@ pub struct SsrCompilerExperimentalOptions {
     pub component_name: Option<String>,
     /// Treat the reserved `<Self>` tag as a reference to the current SFC.
     pub self_component: bool,
+    /// Generate a Source Map v3 document for SSR render code.
+    pub source_map: bool,
+    /// Filename recorded in the Source Map v3 `file` and `sources` fields.
+    pub source_map_filename: Option<String>,
 }

--- a/crates/vize_atelier_ssr/src/source_map_tests.rs
+++ b/crates/vize_atelier_ssr/src/source_map_tests.rs
@@ -1,0 +1,47 @@
+use crate::{
+    SsrCompilerExperimentalOptions, SsrCompilerOptions, compile_ssr,
+    compile_ssr_with_template_syntax_and_experimental_options,
+};
+use vize_atelier_core::TemplateSyntaxMode;
+use vize_s0::Allocator;
+
+#[test]
+fn source_map_disabled_by_default_yields_none() {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_ssr(&allocator, "<div>{{ msg }}</div>");
+
+    assert!(errors.is_empty(), "Errors: {errors:?}");
+    assert!(result.map.is_none());
+}
+
+#[test]
+fn source_map_enabled_emits_v3_document_and_keeps_code() {
+    let allocator = Allocator::new();
+    let source = "<div>{{ msg }}</div>";
+    let (_, without_errors, without_map) = compile_ssr(&allocator, source);
+    let (_, with_errors, with_map) = compile_ssr_with_template_syntax_and_experimental_options(
+        &allocator,
+        source,
+        SsrCompilerOptions::default(),
+        TemplateSyntaxMode::Standard,
+        SsrCompilerExperimentalOptions {
+            source_map: true,
+            source_map_filename: Some("Foo.vue".into()),
+            ..SsrCompilerExperimentalOptions::default()
+        },
+    );
+
+    assert!(without_errors.is_empty(), "Errors: {without_errors:?}");
+    assert!(with_errors.is_empty(), "Errors: {with_errors:?}");
+    assert_eq!(with_map.code, without_map.code);
+    assert_eq!(with_map.preamble, without_map.preamble);
+
+    let map = with_map.map.expect("source_map should attach SSR map");
+    assert!(map.contains("\"version\":3"), "v3 source map: {map}");
+    assert!(map.contains("\"sources\":[\"Foo.vue\"]"), "{map}");
+    assert!(
+        map.contains("\"sourcesContent\":[\"<div>{{ msg }}</div>\"]"),
+        "{map}"
+    );
+    assert!(map.contains("\"mappings\":\"AAAA\""), "{map}");
+}

--- a/crates/vize_atelier_vapor/Cargo.toml
+++ b/crates/vize_atelier_vapor/Cargo.toml
@@ -45,3 +45,10 @@ insta = { workspace = true }
 [[bench]]
 name = "davinci"
 harness = false
+
+[package.metadata.cargo-semver-checks.lints]
+# Vapor is an experimental compiler boundary. P3-9 extends the opt-in
+# source-map API with result/options fields while keeping default output
+# unchanged, so additive preview fields are allowed and release validation owns
+# the versioning decision.
+constructible_struct_adds_field = "allow"

--- a/crates/vize_atelier_vapor/src/compile.rs
+++ b/crates/vize_atelier_vapor/src/compile.rs
@@ -57,6 +57,10 @@ pub struct VaporCompilerExperimentalOptions {
     pub component_name: Option<String>,
     /// Treat the reserved `<Self>` tag as a reference to the current SFC.
     pub self_component: bool,
+    /// Generate a Source Map v3 document for Vapor render code.
+    pub source_map: bool,
+    /// Filename recorded in the Source Map v3 `file` and `sources` fields.
+    pub source_map_filename: Option<String>,
 }
 
 /// Vapor compilation result
@@ -66,6 +70,8 @@ pub struct VaporCompileResult {
     pub code: String,
     /// Template strings for static parts
     pub templates: Vec<String>,
+    /// Source Map v3 JSON for the generated render code.
+    pub map: Option<String>,
     /// Error messages during compilation
     pub error_messages: Vec<String>,
 }
@@ -123,6 +129,7 @@ fn compile_vapor_inner_with_stack<'a>(
             VaporCompileResult {
                 code: String::default(),
                 templates: Vec::new(),
+                map: None,
                 error_messages: fatal.iter().map(|e| e.message.clone()).collect(),
             },
             parser_diagnostics,
@@ -179,6 +186,8 @@ fn compile_vapor_inner_with_stack<'a>(
         crate::generate::VaporGenerateExperimentalOptions {
             component_name: experimental_options.component_name.as_deref(),
             self_component: experimental_options.self_component,
+            source_map: experimental_options.source_map,
+            source_map_filename: experimental_options.source_map_filename.as_deref(),
         },
     );
 
@@ -186,6 +195,7 @@ fn compile_vapor_inner_with_stack<'a>(
         VaporCompileResult {
             code: result.code,
             templates: result.templates,
+            map: result.map,
             error_messages: transform_diagnostics,
         },
         parser_diagnostics,

--- a/crates/vize_atelier_vapor/src/generate/entry.rs
+++ b/crates/vize_atelier_vapor/src/generate/entry.rs
@@ -3,7 +3,9 @@
 use std::fmt::Write;
 
 use crate::ir::{OperationNode, RootIRNode};
-use vize_atelier_core::options::BindingMetadata;
+use vize_atelier_core::{
+    codegen::source_map_anchor::build_single_anchor_source_map, options::BindingMetadata,
+};
 use vize_carton::{FxHashSet, String};
 
 use super::context::GenerateContext;
@@ -19,6 +21,8 @@ pub struct VaporGenerateResult {
     pub code: String,
     /// Static templates
     pub templates: Vec<String>,
+    /// Source Map v3 JSON for the generated render code.
+    pub map: Option<String>,
 }
 
 /// Options for Vapor code generation.
@@ -38,6 +42,10 @@ pub struct VaporGenerateExperimentalOptions<'a> {
     pub component_name: Option<&'a str>,
     /// Treat the reserved `<Self>` tag as a reference to the current SFC.
     pub self_component: bool,
+    /// Generate a Source Map v3 document for Vapor render code.
+    pub source_map: bool,
+    /// Filename recorded in the Source Map v3 `file` and `sources` fields.
+    pub source_map_filename: Option<&'a str>,
 }
 
 /// Generate Vapor code from IR
@@ -182,9 +190,19 @@ pub fn generate_vapor_with_options_and_experimentals(
         final_code.push('\n');
     }
     final_code.push_str(&ctx.code);
+    let map = experimental_options.source_map.then(|| {
+        build_single_anchor_source_map(
+            final_code.as_str(),
+            experimental_options
+                .source_map_filename
+                .unwrap_or("template.vue"),
+            ir.source,
+        )
+    });
 
     VaporGenerateResult {
         code: final_code,
         templates: ir.templates.iter().map(|t| String::new(t)).collect(),
+        map,
     }
 }

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -32,6 +32,8 @@ mod tests_sibling_navigation;
 #[cfg(test)]
 mod tests_slot_outlets;
 #[cfg(test)]
+mod tests_source_map;
+#[cfg(test)]
 mod tests_template_children;
 #[cfg(test)]
 mod tests_valueless_attr;

--- a/crates/vize_atelier_vapor/src/tests_setup_components.rs
+++ b/crates/vize_atelier_vapor/src/tests_setup_components.rs
@@ -49,6 +49,7 @@ fn test_experimental_self_component_resolves_current_component() {
         VaporCompilerExperimentalOptions {
             component_name: Some("TreeNode".into()),
             self_component: true,
+            ..VaporCompilerExperimentalOptions::default()
         },
     );
 

--- a/crates/vize_atelier_vapor/src/tests_source_map.rs
+++ b/crates/vize_atelier_vapor/src/tests_source_map.rs
@@ -1,0 +1,57 @@
+use super::{
+    VaporCompilerExperimentalOptions, VaporCompilerOptions, compile_vapor,
+    compile_vapor_with_experimental_options,
+};
+use vize_carton::Allocator;
+
+#[test]
+fn source_map_disabled_by_default_yields_none() {
+    let allocator = Allocator::new();
+    let result = compile_vapor(
+        &allocator,
+        "<div>{{ msg }}</div>",
+        VaporCompilerOptions::default(),
+    );
+
+    assert!(result.error_messages.is_empty(), "Expected no errors");
+    assert!(result.map.is_none());
+}
+
+#[test]
+fn source_map_enabled_emits_v3_document_and_keeps_code() {
+    let allocator = Allocator::new();
+    let source = "<div>{{ msg }}</div>";
+    let without_map = compile_vapor(&allocator, source, VaporCompilerOptions::default());
+    let with_map = compile_vapor_with_experimental_options(
+        &allocator,
+        source,
+        VaporCompilerOptions::default(),
+        VaporCompilerExperimentalOptions {
+            source_map: true,
+            source_map_filename: Some("Foo.vue".into()),
+            ..VaporCompilerExperimentalOptions::default()
+        },
+    );
+
+    assert!(
+        without_map.error_messages.is_empty(),
+        "Expected no errors: {:?}",
+        without_map.error_messages
+    );
+    assert!(
+        with_map.error_messages.is_empty(),
+        "Expected no errors: {:?}",
+        with_map.error_messages
+    );
+    assert_eq!(with_map.code, without_map.code);
+    assert_eq!(with_map.templates, without_map.templates);
+
+    let map = with_map.map.expect("source_map should attach Vapor map");
+    assert!(map.contains("\"version\":3"), "v3 source map: {map}");
+    assert!(map.contains("\"sources\":[\"Foo.vue\"]"), "{map}");
+    assert!(
+        map.contains("\"sourcesContent\":[\"<div>{{ msg }}</div>\"]"),
+        "{map}"
+    );
+    assert!(map.contains("\"mappings\":\"AAAA\""), "{map}");
+}

--- a/crates/vize_vitrine/src/napi/template.rs
+++ b/crates/vize_vitrine/src/napi/template.rs
@@ -94,6 +94,11 @@ pub fn compile(template: String, options: Option<CompilerOptions>) -> Result<Com
         } else {
             CodegenMode::Function
         },
+        filename: opts
+            .filename
+            .clone()
+            .unwrap_or_else(|| "template.vue".to_string())
+            .into(),
         component_name: self_component_name(&opts).map(Into::into),
         source_map: opts.source_map.unwrap_or(false),
         ssr: opts.ssr.unwrap_or(false),
@@ -115,6 +120,11 @@ pub fn compile(template: String, options: Option<CompilerOptions>) -> Result<Com
         self_component: opts.experimental_self_component.unwrap_or(false),
     };
     let result = generate_with_experimental_options(&root, codegen_opts, codegen_experimental_opts);
+    let map = result
+        .map
+        .map(|map| serde_json::from_str(map.as_str()))
+        .transpose()
+        .map_err(|error| Error::new(Status::GenericFailure, error.to_string()))?;
 
     // Collect helpers
     let helpers: Vec<String> = root.helpers.iter().map(|h| h.name().to_string()).collect();
@@ -126,7 +136,7 @@ pub fn compile(template: String, options: Option<CompilerOptions>) -> Result<Com
         code: result.code.to_string(),
         preamble: result.preamble.to_string(),
         ast,
-        map: None,
+        map,
         helpers,
         templates: None,
     })
@@ -152,6 +162,8 @@ pub fn compile_vapor(template: String, options: Option<CompilerOptions>) -> Resu
     let vapor_experimental_opts = VaporCompilerExperimentalOptions {
         component_name: self_component_name(&opts).map(Into::into),
         self_component: opts.experimental_self_component.unwrap_or(false),
+        source_map: opts.source_map.unwrap_or(false),
+        source_map_filename: opts.filename.clone().map(Into::into),
     };
     let result = compile_vapor_with_custom_elements_template_syntax_and_experimental_options(
         &allocator,
@@ -175,12 +187,17 @@ pub fn compile_vapor(template: String, options: Option<CompilerOptions>) -> Resu
                 .join("\n"),
         ));
     }
+    let map = result
+        .map
+        .map(|map| serde_json::from_str(map.as_str()))
+        .transpose()
+        .map_err(|error| Error::new(Status::GenericFailure, error.to_string()))?;
 
     Ok(CompileResult {
         code: result.code.into(),
         preamble: String::new(),
         ast: serde_json::json!({}),
-        map: None,
+        map,
         helpers: vec![],
         templates: Some(result.templates.iter().map(|s| s.to_string()).collect()),
     })
@@ -282,4 +299,26 @@ fn build_ast_json(root: &vize_atelier_core::RootNode<'_>) -> serde_json::Value {
         "components": root.components.iter().copied().collect::<Vec<_>>(),
         "directives": root.directives.iter().copied().collect::<Vec<_>>(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compile_source_map_uses_requested_filename() {
+        let result = compile(
+            "<div>{{ msg }}</div>".to_string(),
+            Some(CompilerOptions {
+                filename: Some("src/Napi.vue".to_string()),
+                source_map: Some(true),
+                ..Default::default()
+            }),
+        )
+        .expect("compile should succeed");
+        let map = result.map.expect("sourceMap should attach a map");
+
+        assert_eq!(map["file"].as_str(), Some("src/Napi.vue"));
+        assert_eq!(map["sources"][0].as_str(), Some("src/Napi.vue"));
+    }
 }

--- a/crates/vize_vitrine/src/wasm/compiler/pipeline.rs
+++ b/crates/vize_vitrine/src/wasm/compiler/pipeline.rs
@@ -44,6 +44,8 @@ pub(in crate::wasm) fn compile_internal(
         let ssr_experimental_opts = SsrCompilerExperimentalOptions {
             component_name: self_component_name(opts).map(Into::into),
             self_component: experimental_self_component,
+            source_map: opts.source_map.unwrap_or(false),
+            source_map_filename: opts.filename.clone().map(Into::into),
         };
         let (root, errors, result) =
             compile_ssr_with_custom_elements_template_syntax_and_experimental_options(
@@ -65,7 +67,7 @@ pub(in crate::wasm) fn compile_internal(
             code: result.code.to_string(),
             preamble: result.preamble.to_string(),
             ast: build_ast_json(&root),
-            map: None,
+            map: parse_codegen_map(result.map)?,
             helpers: root.helpers.iter().map(|h| h.name().to_string()).collect(),
             templates: None,
         });
@@ -84,6 +86,8 @@ pub(in crate::wasm) fn compile_internal(
         let vapor_experimental_opts = VaporCompilerExperimentalOptions {
             component_name: self_component_name(opts).map(Into::into),
             self_component: experimental_self_component,
+            source_map: opts.source_map.unwrap_or(false),
+            source_map_filename: opts.filename.clone().map(Into::into),
         };
         let result = compile_vapor_with_custom_elements_template_syntax_and_experimental_options(
             &allocator,
@@ -105,7 +109,7 @@ pub(in crate::wasm) fn compile_internal(
             code: result.code.to_string(),
             preamble: String::new(),
             ast: serde_json::json!({}),
-            map: None,
+            map: parse_codegen_map(result.map)?,
             helpers: vec![],
             templates: Some(
                 result
@@ -168,6 +172,12 @@ pub(in crate::wasm) fn compile_internal(
         helpers: root.helpers.iter().map(|h| h.name().to_string()).collect(),
         templates: None,
     })
+}
+
+fn parse_codegen_map<T: AsRef<str>>(map: Option<T>) -> Result<Option<serde_json::Value>, String> {
+    map.map(|map| serde_json::from_str(map.as_ref()))
+        .transpose()
+        .map_err(|error| format!("Codegen emitted an invalid source map: {error}"))
 }
 
 fn custom_elements(opts: &CompilerOptions) -> CustomElementMatcher {

--- a/crates/vize_vitrine/src/wasm/tests.rs
+++ b/crates/vize_vitrine/src/wasm/tests.rs
@@ -95,6 +95,45 @@ fn compiler_options_change_runtime_names_syntax_and_source_maps() {
             .and_then(|map| map["sources"][0].as_str()),
         Some("src/Component.vue")
     );
+
+    let ssr_with_map = compile_internal(
+        "<div>{{ message }}</div>",
+        &CompilerOptions {
+            ssr: Some(true),
+            source_map: Some(true),
+            filename: Some("src/Ssr.vue".to_string()),
+            ..Default::default()
+        },
+        false,
+        None,
+    )
+    .expect("SSR source-map compile should succeed");
+    assert_eq!(
+        ssr_with_map
+            .map
+            .as_ref()
+            .and_then(|map| map["sources"][0].as_str()),
+        Some("src/Ssr.vue")
+    );
+
+    let vapor_with_map = compile_internal(
+        "<div>{{ message }}</div>",
+        &CompilerOptions {
+            source_map: Some(true),
+            filename: Some("src/Vapor.vue".to_string()),
+            ..Default::default()
+        },
+        true,
+        None,
+    )
+    .expect("Vapor source-map compile should succeed");
+    assert_eq!(
+        vapor_with_map
+            .map
+            .as_ref()
+            .and_then(|map| map["sources"][0].as_str()),
+        Some("src/Vapor.vue")
+    );
 }
 
 #[test]

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -313,6 +313,24 @@ ssr_rewritten_identifier = { backend = "ssr", category = "rewritten-identifier",
 ssr_section_boundary = { backend = "ssr", category = "section-boundary", anchors_min = 3, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
 legacy_sfc_text_matching_recovery = { backend = "legacy-sfc", category = "text-matching-recovery", anchors_min = 7, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
 
+[optimization]
+# P3-10 Try-measure-commit extraction tiers. Each `candidate_budget` is the
+# per-component decrementing budget for one compile, keyed to the future `-O`
+# selection. `reactive_edge` and `update_path` are correctness-adjacent
+# constraints, so their epsilons start at zero; emitted size is the objective
+# but may not regress unless this table is deliberately loosened.
+o0 = { tier = "O0", candidate_budget = 0, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 0, tie_policy = "reject" }
+o1 = { tier = "O1", candidate_budget = 8, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 1, tie_policy = "reject" }
+o2 = { tier = "O2", candidate_budget = 32, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 1, tie_policy = "reject" }
+o3 = { tier = "O3", candidate_budget = 128, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 1, tie_policy = "reject" }
+
+[target.p3-10]
+task_start_rev = "b891e186eb92bc8c4fe84cfcc838cdb5ceece841"
+task_start_date = "2026-09-13"
+objective_metric = "emitted-size"
+constraint_metrics = ["reactive-edge", "update-path"]
+tie_policy = "reject"
+
 [resource]
 # Resident-tier ceilings: rss_peak_bytes per machine preset, cold_start_ms,
 # idle_cpu_pct (mean over a 60 s idle window), keystroke_p95_ms — with the

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |          1167 |                   813 |               354 |             158 |     373 |            1030 |      668 |           575 |           716 |
+| Compiler                   |          1170 |                   815 |               355 |             158 |     373 |            1032 |      669 |           578 |           719 |
 | Linter                     |           373 |                   373 |                 0 |             298 |     301 |             726 |      246 |           388 |           569 |
 | Typechecker                |           957 |                   260 |               697 |             439 |     214 |             896 |      714 |           516 |           735 |
 | Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          30 |              10 |       20 |
-| S0               |         965 |             510 |      455 |
+| S0               |         968 |             512 |      456 |
 | S1               |          12 |               5 |        7 |
 | S2               |          44 |              24 |       20 |
 | S1->S2           |         116 |              15 |      101 |
@@ -79,7 +79,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | `crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs:6` | source   | S0 2<br>raw OXC 15                                                                                   |    17 |
 | `crates/vize_atelier_core/src/steps/expression/prefix.rs:6`                  | source   | S0 1<br>Croquis analysis 1<br>raw OXC 14                                                             |    16 |
 
-Additional source/manifest rows are in the TSV: 339 omitted.
+Additional source/manifest rows are in the TSV: 341 omitted.
 
 #### Top test/dev files
 
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 339 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 3<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 4 |    13 |
 
-Additional test/dev rows are in the TSV: 265 omitted.
+Additional test/dev rows are in the TSV: 266 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -80,6 +80,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map_anchor.rs	1	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0	stage	vize_s0	preferred	20
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -905,7 +906,7 @@ compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	s1_to_s2	S1->S2
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	old_ast	old AST/parser	old	vize_armature	legacy	2
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen.rs	14	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen.rs	17	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/component_binding.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/component_resolution.rs	2	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element.rs	17	s0	S0	stage	vize_s0	preferred	2
@@ -933,6 +934,7 @@ compiler	Compiler	source	crates/vize_atelier_ssr/src/s4/string_plan/binding.rs	1
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/s4/string_plan/tests.rs	2	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/s4/string_plan/tests.rs	2	s1	S1	stage	vize_s1	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/s4/string_plan/tests.rs	2	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/source_map_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_ssr/src/stage_options.rs	14	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/steps.rs	93	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/component_spread_props.rs	10	s0	S0	stage	vize_s0	preferred	1
@@ -963,7 +965,7 @@ compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context/componen
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context/scopes.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/destructure.rs	2	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generate/destructure.rs	262	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/entry.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/entry.rs	9	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
@@ -1041,6 +1043,7 @@ compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_sibling_navigation.
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_slot_outlets.rs	8	s0	S0	stage	vize_carton	compat	4
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_slot_outlets.rs	8	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_slot_outlets.rs	8	raw_oxc	raw OXC	raw	oxc_parser	raw	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_source_map.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_template_children.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_valueless_attr.rs	4	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_valueless_attr.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1

--- a/davinci-road/plan/phase-3-records/p3-10.md
+++ b/davinci-road/plan/phase-3-records/p3-10.md
@@ -1,0 +1,35 @@
+# P3-10 - Try-measure-commit budget pin
+
+This slice fixes the contract before the extraction pass can choose winners.
+It does not add extraction behavior yet.
+
+## Budget Contract
+
+`davinci-road/plan/budgets.toml` now carries:
+
+- `[optimization]` rows for `-O0` through `-O3`.
+- `candidate_budget`, the per-component decrementing budget for trying
+  hoist/cache/inline/group placements.
+- Per-metric epsilons for emitted size, reactive-edge count, and update-path
+  length.
+- `required_improvements_min`, which keeps `-O1` and above from committing a
+  tie.
+- `tie_policy = "reject"` on every tier.
+- `[target.p3-10]`, which records the task-start revision and the metric roles.
+
+The starting policy is intentionally strict: `reactive-edge` and `update-path`
+are correctness-adjacent constraints, emitted size is the objective, and all
+epsilons begin at zero. Loosening any value must go through the existing budget
+ratchet process.
+
+## Mechanical Witnesses
+
+- `node --test tests/tooling/davinci-optimization-budgets.test.ts`
+- `node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-traversal-budgets.test.ts tests/tooling/davinci-sourcemap-budgets.test.ts tests/tooling/davinci-optimization-budgets.test.ts`
+- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
+
+## Follow-up
+
+P3-10 still needs explicit S3 placement alternatives, the try-measure-commit
+pass, TS-17 decision snapshots, and TS-32 optimization remarks for applied and
+missed candidates.

--- a/davinci-road/plan/phase-3-records/p3-9.md
+++ b/davinci-road/plan/phase-3-records/p3-9.md
@@ -25,3 +25,26 @@ path must show coverage at least as good as this legacy row before removal.
 The checker lives in `tests/tooling/davinci-sourcemap-budgets.test.ts`; it
 keeps `[sourcemap]` non-empty, verifies every DOM/Vapor/SSR category cell, and
 rejects malformed or non-numeric budget rows.
+
+## Slice 2: SSR/Vapor Map Entry Points
+
+This slice wires the shared Source Map v3 builder contract into non-DOM
+backends without changing generated JavaScript bytes.
+
+- `vize_atelier_core::codegen::source_map::build_single_anchor_source_map`
+  exposes a minimal one-source map helper for backends that have not migrated
+  every emitted token onto structured span segments yet.
+- `vize_atelier_ssr` now carries `SsrCodegenResult::map` and an opt-in
+  `SsrCompilerExperimentalOptions::source_map` gate.
+- `vize_atelier_vapor` now carries `VaporCompileResult::map`,
+  `VaporGenerateResult::map`, and an opt-in
+  `VaporCompilerExperimentalOptions::source_map` gate.
+- NAPI/WASM direct template compilation now preserves source maps for DOM,
+  SSR, and Vapor when `sourceMap: true` is requested.
+
+This is intentionally not the P3-9 finish line. The map currently records the
+module-start anchor so consumers can rely on result shape, `sources`, and
+`sourcesContent` across all three backends. Later P3-9 slices must replace
+these minimum anchors with token-level structured emission and then retire the
+legacy SFC text-matching recovery once TS-31 coverage proves the new path is at
+least as strong.

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -113,6 +113,11 @@ _Accept:_ TS-31 coverage budget — **the numeric threshold is pinned in
 `budgets.toml` before this task merges**, and the text-matching recovery may
 only be deleted once the new path's measured coverage ≥ the old heuristic's
 measured coverage; TS-11 empty (maps are additive artifacts).
+_First slice 2026-09-13:_ see
+[P3-9 record](./phase-3-records/p3-9.md) for the TS-31 budget pin.
+_Second slice 2026-09-13:_ the same record now covers SSR/Vapor opt-in map
+entry points and binding bridge propagation. Token-level structured emission,
+coverage measurement, and legacy recovery removal remain open.
 
 **P3-10 Try-measure-commit.** Placement alternatives (hoist/cache/inline/
 group) kept explicit on S3 nodes; extraction pass performs candidates,

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -15,7 +15,7 @@
 - [ ] P3-7 VDOM patch flags from lattice facts
 - [ ] P3-8 SSR thin path
 - [ ] P3-9 S4 structured emitter + universal source maps _(slice 1 pins TS-31 source-map budgets before emitter migration; see [record](./phase-3-records/p3-9.md))_
-- [ ] P3-10 Try-measure-commit extraction
+- [ ] P3-10 Try-measure-commit extraction _(slice 1 pins optimization budgets before extraction; see [record](./phase-3-records/p3-10.md))_
 - [ ] P3-11 IVM oracle
 - [ ] P3-12 Behavioral (sprout) runner incl. IME scripts
 - [ ] P3-13 Optimization remarks + corpus remarks-diff
@@ -130,6 +130,10 @@ pinned in `budgets.toml` at task start from corpus distributions, ties reject
 in favor of the simpler shape) — under a decrementing per-component budget;
 `-O` tiers = budget constants in `budgets.toml`. _Accept:_ TS-17 snapshots of decisions; TS-32 remarks record
 applied/missed; no output regression (TS-11/TS-33).
+_First slice 2026-09-13:_ see
+[P3-10 record](./phase-3-records/p3-10.md) for the task-start budget pin,
+zero-epsilon metric policy, and `-O0` through `-O3` candidate budgets. The S3
+placement alternatives and extraction pass remain open.
 
 **P3-11 IVM oracle.** Incremental-update ≡ from-scratch render on the Lean
 reference for keyed/unkeyed `v-for`, conditional toggles, mixed non-linear

--- a/tests/tooling/davinci-optimization-budgets.test.ts
+++ b/tests/tooling/davinci-optimization-budgets.test.ts
@@ -1,0 +1,136 @@
+// Davinci optimization budgets (plan/phase-3.md P3-10).
+//
+// P3-10's try-measure-commit pass is allowed to choose an extraction only
+// after the metric rule is pinned. This test keeps the `-O` tiers, candidate
+// budgets, epsilons and tie policy reviewable before the pass implementation
+// lands.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { parseTomlLite } from "../../legacy-tools/davinci/toml-lite.mjs";
+
+type OptimizationBudget = {
+  tier: string;
+  candidate_budget: number;
+  emitted_size_epsilon_pct: number;
+  reactive_edge_epsilon_pct: number;
+  update_path_epsilon_pct: number;
+  required_improvements_min: number;
+  tie_policy: string;
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const budgetsPath = path.join(repoRoot, "davinci-road", "plan", "budgets.toml");
+const budgetsText = fs.readFileSync(budgetsPath, "utf8");
+const budgets = parseTomlLite(budgetsText) as {
+  optimization: Record<string, OptimizationBudget>;
+  target: Record<string, Record<string, unknown>>;
+};
+
+const REQUIRED_TIERS = [
+  ["o0", "O0", 0, 0],
+  ["o1", "O1", 8, 1],
+  ["o2", "O2", 32, 1],
+  ["o3", "O3", 128, 1],
+] as const;
+
+function inlineTableLines(section: string): string[] {
+  const lines = budgetsText.split("\n");
+  const start = lines.indexOf(`[${section}]`);
+  assert.ok(start >= 0, `budgets.toml must declare a [${section}] section`);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith("["));
+  const body = end === -1 ? rest : rest.slice(0, end);
+  return body.filter((line) => /^[A-Za-z0-9._-]+ = \{/.test(line));
+}
+
+function assertPercent(value: unknown, field: string, id: string): asserts value is number {
+  assert.ok(
+    Number.isSafeInteger(value) && value >= 0 && value <= 100,
+    `[optimization.${id}] ${field} must be a 0..100 integer, got ${String(value)}`,
+  );
+}
+
+test("optimization budgets pin every P3-10 -O tier", () => {
+  assert.deepEqual(Object.keys(budgets.optimization).sort(), REQUIRED_TIERS.map(([id]) => id));
+  for (const [id, tier, candidateBudget, requiredImprovements] of REQUIRED_TIERS) {
+    const entry = budgets.optimization[id];
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      [
+        "candidate_budget",
+        "emitted_size_epsilon_pct",
+        "reactive_edge_epsilon_pct",
+        "required_improvements_min",
+        "tie_policy",
+        "tier",
+        "update_path_epsilon_pct",
+      ],
+      `[optimization.${id}] must keep the documented field set`,
+    );
+    assert.equal(entry.tier, tier);
+    assert.equal(entry.candidate_budget, candidateBudget);
+    assert.equal(entry.required_improvements_min, requiredImprovements);
+    assert.equal(entry.tie_policy, "reject");
+    assertPercent(entry.emitted_size_epsilon_pct, "emitted_size_epsilon_pct", id);
+    assertPercent(entry.reactive_edge_epsilon_pct, "reactive_edge_epsilon_pct", id);
+    assertPercent(entry.update_path_epsilon_pct, "update_path_epsilon_pct", id);
+  }
+});
+
+test("optimization budgets are monotone and reject ties above O0", () => {
+  let previousBudget = -1;
+  for (const [id] of REQUIRED_TIERS) {
+    const entry = budgets.optimization[id];
+    assert.ok(
+      entry.candidate_budget > previousBudget,
+      `[optimization.${id}] candidate_budget must increase with optimization level`,
+    );
+    previousBudget = entry.candidate_budget;
+    assert.equal(
+      entry.reactive_edge_epsilon_pct,
+      0,
+      `[optimization.${id}] reactive-edge regressions are not allowed at task start`,
+    );
+    assert.equal(
+      entry.update_path_epsilon_pct,
+      0,
+      `[optimization.${id}] update-path regressions are not allowed at task start`,
+    );
+    assert.equal(entry.emitted_size_epsilon_pct, 0);
+    assert.equal(entry.required_improvements_min, id === "o0" ? 0 : 1);
+  }
+});
+
+test("optimization entries are one-line inline tables", () => {
+  const entryLines = inlineTableLines("optimization");
+  assert.equal(entryLines.length, REQUIRED_TIERS.length);
+  for (const line of entryLines) {
+    assert.match(
+      line,
+      /^[A-Za-z0-9._-]+ = \{ tier = "O[0-3]", candidate_budget = \d+, emitted_size_epsilon_pct = \d+, reactive_edge_epsilon_pct = \d+, update_path_epsilon_pct = \d+, required_improvements_min = \d+, tie_policy = "reject" \}$/,
+      `optimization entries must keep the canonical field order and spacing:\n${line}`,
+    );
+  }
+});
+
+test("P3-10 target records the metric roles and task-start revision", () => {
+  const target = budgets.target?.["p3-10"];
+  assert.ok(target, "budgets.toml must carry a [target.p3-10] table");
+  assert.ok(
+    typeof target.task_start_rev === "string" && /^[0-9a-f]{40}$/.test(target.task_start_rev),
+    `[target.p3-10] task_start_rev must be a full 40-hex commit sha`,
+  );
+  assert.match(
+    String(target.task_start_date),
+    /^\d{4}-\d{2}-\d{2}$/,
+    "[target.p3-10] task_start_date must be an ISO date string",
+  );
+  assert.equal(target.objective_metric, "emitted-size");
+  assert.deepEqual(target.constraint_metrics, ["reactive-edge", "update-path"]);
+  assert.equal(target.tie_policy, "reject");
+});

--- a/tests/tooling/davinci-optimization-budgets.test.ts
+++ b/tests/tooling/davinci-optimization-budgets.test.ts
@@ -56,7 +56,10 @@ function assertPercent(value: unknown, field: string, id: string): asserts value
 }
 
 test("optimization budgets pin every P3-10 -O tier", () => {
-  assert.deepEqual(Object.keys(budgets.optimization).sort(), REQUIRED_TIERS.map(([id]) => id));
+  assert.deepEqual(
+    Object.keys(budgets.optimization).sort(),
+    REQUIRED_TIERS.map(([id]) => id),
+  );
   for (const [id, tier, candidateBudget, requiredImprovements] of REQUIRED_TIERS) {
     const entry = budgets.optimization[id];
     assert.deepEqual(


### PR DESCRIPTION
## Summary
- add opt-in Source Map v3 results for SSR and Vapor codegen
- surface SSR/Vapor source maps through NAPI and WASM template compile paths
- record the P3-9 second source-map slice and refresh migration inventories

## Verification
- cargo fmt --check
- git diff --check
- CARGO_INCREMENTAL=0 cargo test -p vize_atelier_ssr source_map --lib -- --nocapture
- CARGO_INCREMENTAL=0 cargo test -p vize_atelier_vapor source_map --lib -- --nocapture
- CARGO_INCREMENTAL=0 cargo check -p vize_vitrine --lib --no-default-features
- CARGO_INCREMENTAL=0 cargo check -p vize_vitrine --lib --no-default-features --features wasm
- CARGO_INCREMENTAL=0 cargo check -p vize_vitrine --lib --no-default-features --features napi
- node --test tests/tooling/davinci-sourcemap-budgets.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791846949&installation_model_id=422833&pr_number=6072&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6072&signature=70c836685b598d41015cc73e50ebe2a3526b19fa38ddb735ef59399f36a262d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Source Map v3 generation for SSR and Vapor compilation.
  * Source maps preserve configured filenames and embedded source content.
  * NAPI and WASM compilation results now expose source maps for supported template types.
  * Generated JavaScript remains unchanged when source maps are enabled.

* **Documentation**
  * Updated planning and usage documentation for source-map support and optimization budgets.

* **Tests**
  * Added coverage for source-map output, defaults, filenames, and preserved generated code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->