### PR TITLE
test(davinci): pin optimization extraction budgets

### DIFF
--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -313,6 +313,24 @@ ssr_rewritten_identifier = { backend = "ssr", category = "rewritten-identifier",
 ssr_section_boundary = { backend = "ssr", category = "section-boundary", anchors_min = 3, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
 legacy_sfc_text_matching_recovery = { backend = "legacy-sfc", category = "text-matching-recovery", anchors_min = 7, coverage_pct_min = 100, span_accuracy_pct_min = 100 }
 
+[optimization]
+# P3-10 Try-measure-commit extraction tiers. Each `candidate_budget` is the
+# per-component decrementing budget for one compile, keyed to the future `-O`
+# selection. `reactive_edge` and `update_path` are correctness-adjacent
+# constraints, so their epsilons start at zero; emitted size is the objective
+# but may not regress unless this table is deliberately loosened.
+o0 = { tier = "O0", candidate_budget = 0, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 0, tie_policy = "reject" }
+o1 = { tier = "O1", candidate_budget = 8, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 1, tie_policy = "reject" }
+o2 = { tier = "O2", candidate_budget = 32, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 1, tie_policy = "reject" }
+o3 = { tier = "O3", candidate_budget = 128, emitted_size_epsilon_pct = 0, reactive_edge_epsilon_pct = 0, update_path_epsilon_pct = 0, required_improvements_min = 1, tie_policy = "reject" }
+
+[target.p3-10]
+task_start_rev = "b891e186eb92bc8c4fe84cfcc838cdb5ceece841"
+task_start_date = "2026-09-13"
+objective_metric = "emitted-size"
+constraint_metrics = ["reactive-edge", "update-path"]
+tie_policy = "reject"
+
 [resource]
 # Resident-tier ceilings: rss_peak_bytes per machine preset, cold_start_ms,
 # idle_cpu_pct (mean over a 60 s idle window), keystroke_p95_ms — with the

--- a/davinci-road/plan/phase-3-records/p3-10.md
+++ b/davinci-road/plan/phase-3-records/p3-10.md
@@ -1,0 +1,35 @@
+# P3-10 - Try-measure-commit budget pin
+
+This slice fixes the contract before the extraction pass can choose winners.
+It does not add extraction behavior yet.
+
+## Budget Contract
+
+`davinci-road/plan/budgets.toml` now carries:
+
+- `[optimization]` rows for `-O0` through `-O3`.
+- `candidate_budget`, the per-component decrementing budget for trying
+  hoist/cache/inline/group placements.
+- Per-metric epsilons for emitted size, reactive-edge count, and update-path
+  length.
+- `required_improvements_min`, which keeps `-O1` and above from committing a
+  tie.
+- `tie_policy = "reject"` on every tier.
+- `[target.p3-10]`, which records the task-start revision and the metric roles.
+
+The starting policy is intentionally strict: `reactive-edge` and `update-path`
+are correctness-adjacent constraints, emitted size is the objective, and all
+epsilons begin at zero. Loosening any value must go through the existing budget
+ratchet process.
+
+## Mechanical Witnesses
+
+- `node --test tests/tooling/davinci-optimization-budgets.test.ts`
+- `node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-traversal-budgets.test.ts tests/tooling/davinci-sourcemap-budgets.test.ts tests/tooling/davinci-optimization-budgets.test.ts`
+- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
+
+## Follow-up
+
+P3-10 still needs explicit S3 placement alternatives, the try-measure-commit
+pass, TS-17 decision snapshots, and TS-32 optimization remarks for applied and
+missed candidates.

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -15,7 +15,7 @@
 - [ ] P3-7 VDOM patch flags from lattice facts
 - [ ] P3-8 SSR thin path
 - [ ] P3-9 S4 structured emitter + universal source maps _(slice 1 pins TS-31 source-map budgets before emitter migration; see [record](./phase-3-records/p3-9.md))_
-- [ ] P3-10 Try-measure-commit extraction
+- [ ] P3-10 Try-measure-commit extraction _(slice 1 pins optimization budgets before extraction; see [record](./phase-3-records/p3-10.md))_
 - [ ] P3-11 IVM oracle
 - [ ] P3-12 Behavioral (sprout) runner incl. IME scripts
 - [ ] P3-13 Optimization remarks + corpus remarks-diff
@@ -130,6 +130,10 @@ pinned in `budgets.toml` at task start from corpus distributions, ties reject
 in favor of the simpler shape) — under a decrementing per-component budget;
 `-O` tiers = budget constants in `budgets.toml`. _Accept:_ TS-17 snapshots of decisions; TS-32 remarks record
 applied/missed; no output regression (TS-11/TS-33).
+_First slice 2026-09-13:_ see
+[P3-10 record](./phase-3-records/p3-10.md) for the task-start budget pin,
+zero-epsilon metric policy, and `-O0` through `-O3` candidate budgets. The S3
+placement alternatives and extraction pass remain open.
 
 **P3-11 IVM oracle.** Incremental-update ≡ from-scratch render on the Lean
 reference for keyed/unkeyed `v-for`, conditional toggles, mixed non-linear

--- a/tests/tooling/davinci-optimization-budgets.test.ts
+++ b/tests/tooling/davinci-optimization-budgets.test.ts
@@ -1,0 +1,136 @@
+// Davinci optimization budgets (plan/phase-3.md P3-10).
+//
+// P3-10's try-measure-commit pass is allowed to choose an extraction only
+// after the metric rule is pinned. This test keeps the `-O` tiers, candidate
+// budgets, epsilons and tie policy reviewable before the pass implementation
+// lands.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { parseTomlLite } from "../../legacy-tools/davinci/toml-lite.mjs";
+
+type OptimizationBudget = {
+  tier: string;
+  candidate_budget: number;
+  emitted_size_epsilon_pct: number;
+  reactive_edge_epsilon_pct: number;
+  update_path_epsilon_pct: number;
+  required_improvements_min: number;
+  tie_policy: string;
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const budgetsPath = path.join(repoRoot, "davinci-road", "plan", "budgets.toml");
+const budgetsText = fs.readFileSync(budgetsPath, "utf8");
+const budgets = parseTomlLite(budgetsText) as {
+  optimization: Record<string, OptimizationBudget>;
+  target: Record<string, Record<string, unknown>>;
+};
+
+const REQUIRED_TIERS = [
+  ["o0", "O0", 0, 0],
+  ["o1", "O1", 8, 1],
+  ["o2", "O2", 32, 1],
+  ["o3", "O3", 128, 1],
+] as const;
+
+function inlineTableLines(section: string): string[] {
+  const lines = budgetsText.split("\n");
+  const start = lines.indexOf(`[${section}]`);
+  assert.ok(start >= 0, `budgets.toml must declare a [${section}] section`);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => line.startsWith("["));
+  const body = end === -1 ? rest : rest.slice(0, end);
+  return body.filter((line) => /^[A-Za-z0-9._-]+ = \{/.test(line));
+}
+
+function assertPercent(value: unknown, field: string, id: string): asserts value is number {
+  assert.ok(
+    Number.isSafeInteger(value) && value >= 0 && value <= 100,
+    `[optimization.${id}] ${field} must be a 0..100 integer, got ${String(value)}`,
+  );
+}
+
+test("optimization budgets pin every P3-10 -O tier", () => {
+  assert.deepEqual(Object.keys(budgets.optimization).sort(), REQUIRED_TIERS.map(([id]) => id));
+  for (const [id, tier, candidateBudget, requiredImprovements] of REQUIRED_TIERS) {
+    const entry = budgets.optimization[id];
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      [
+        "candidate_budget",
+        "emitted_size_epsilon_pct",
+        "reactive_edge_epsilon_pct",
+        "required_improvements_min",
+        "tie_policy",
+        "tier",
+        "update_path_epsilon_pct",
+      ],
+      `[optimization.${id}] must keep the documented field set`,
+    );
+    assert.equal(entry.tier, tier);
+    assert.equal(entry.candidate_budget, candidateBudget);
+    assert.equal(entry.required_improvements_min, requiredImprovements);
+    assert.equal(entry.tie_policy, "reject");
+    assertPercent(entry.emitted_size_epsilon_pct, "emitted_size_epsilon_pct", id);
+    assertPercent(entry.reactive_edge_epsilon_pct, "reactive_edge_epsilon_pct", id);
+    assertPercent(entry.update_path_epsilon_pct, "update_path_epsilon_pct", id);
+  }
+});
+
+test("optimization budgets are monotone and reject ties above O0", () => {
+  let previousBudget = -1;
+  for (const [id] of REQUIRED_TIERS) {
+    const entry = budgets.optimization[id];
+    assert.ok(
+      entry.candidate_budget > previousBudget,
+      `[optimization.${id}] candidate_budget must increase with optimization level`,
+    );
+    previousBudget = entry.candidate_budget;
+    assert.equal(
+      entry.reactive_edge_epsilon_pct,
+      0,
+      `[optimization.${id}] reactive-edge regressions are not allowed at task start`,
+    );
+    assert.equal(
+      entry.update_path_epsilon_pct,
+      0,
+      `[optimization.${id}] update-path regressions are not allowed at task start`,
+    );
+    assert.equal(entry.emitted_size_epsilon_pct, 0);
+    assert.equal(entry.required_improvements_min, id === "o0" ? 0 : 1);
+  }
+});
+
+test("optimization entries are one-line inline tables", () => {
+  const entryLines = inlineTableLines("optimization");
+  assert.equal(entryLines.length, REQUIRED_TIERS.length);
+  for (const line of entryLines) {
+    assert.match(
+      line,
+      /^[A-Za-z0-9._-]+ = \{ tier = "O[0-3]", candidate_budget = \d+, emitted_size_epsilon_pct = \d+, reactive_edge_epsilon_pct = \d+, update_path_epsilon_pct = \d+, required_improvements_min = \d+, tie_policy = "reject" \}$/,
+      `optimization entries must keep the canonical field order and spacing:\n${line}`,
+    );
+  }
+});
+
+test("P3-10 target records the metric roles and task-start revision", () => {
+  const target = budgets.target?.["p3-10"];
+  assert.ok(target, "budgets.toml must carry a [target.p3-10] table");
+  assert.ok(
+    typeof target.task_start_rev === "string" && /^[0-9a-f]{40}$/.test(target.task_start_rev),
+    `[target.p3-10] task_start_rev must be a full 40-hex commit sha`,
+  );
+  assert.match(
+    String(target.task_start_date),
+    /^\d{4}-\d{2}-\d{2}$/,
+    "[target.p3-10] task_start_date must be an ISO date string",
+  );
+  assert.equal(target.objective_metric, "emitted-size");
+  assert.deepEqual(target.constraint_metrics, ["reactive-edge", "update-path"]);
+  assert.equal(target.tie_policy, "reject");
+});


### PR DESCRIPTION
## Summary
- add P3-10 optimization budgets for -O0 through -O3
- pin task-start metric roles and strict tie rejection in budgets.toml
- add a dedicated tooling test and P3-10 record

## Verification
- node --test tests/tooling/davinci-optimization-budgets.test.ts
- node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-traversal-budgets.test.ts tests/tooling/davinci-sourcemap-budgets.test.ts tests/tooling/davinci-optimization-budgets.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791850537&installation_model_id=422833&pr_number=6073&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6073&signature=dabd9c3d6405e8707338eb033e58a956dcf4387971579ad79852ad4d202bc1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->