### PR TITLE
feat(davinci): materialize patch facts table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,6 +4073,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_transformer",
+ "smallvec",
  "toml",
  "vize_atelier_core",
  "vize_atelier_dom",

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -45,6 +45,7 @@ oxc_semantic = { workspace = true }
 oxc_transformer = { workspace = true, optional = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
+smallvec = { workspace = true }
 vize_s0 = { workspace = true }
 vize_davinci = { workspace = true }
 vize_s1 = { workspace = true }

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -147,6 +147,7 @@ struct EmitCx<'facts> {
     scopes: &'facts SideTable<ScopeFacts>,
     wrappers: &'facts SideTable<WrapperKeys>,
     for_wrappers: &'facts SideTable<ForWrapper>,
+    patch_facts: patch::PatchFactsTable,
     walk: PageWalk,
     scope_names: StdVec<String>,
     /// Sibling `v-if` chains share one counter; nested chains reset.

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -23,9 +23,7 @@ use super::create_slots;
 use super::directive;
 use super::flag::emit_patch_flag;
 use super::js::asset_ident;
-use super::patch::{
-    apply_static_ref_patch, binding_patch_facts, prune_legacy_patchless_dynamic_props,
-};
+use super::patch::{apply_static_ref_patch, prune_legacy_patchless_dynamic_props};
 use super::props::{BindPropsOptions, emit_bind_props};
 use super::props_dynamic::emit_dynamic_props;
 use super::props_static;
@@ -166,16 +164,7 @@ pub(super) fn emit_call(
                 .clone(),
         );
     }
-    let mut patch = binding_patch_facts(
-        &component.bindings,
-        true,
-        if_key,
-        for_item,
-        cx.is_ts,
-        &|name| cx.reads_constant_binding_name(name),
-        &|on| super::on::caches_handler(cx, on),
-        cx.caches_handlers(),
-    );
+    let mut patch = cx.materialize_patch_facts(id, &component.bindings, true, if_key, for_item);
     if skip_is {
         patch.dynamic_props.retain(|name| name.as_str() != "is");
         if patch.dynamic_props.is_empty() {

--- a/crates/vize_s1_to_s2/src/emit/dispatch.rs
+++ b/crates/vize_s1_to_s2/src/emit/dispatch.rs
@@ -21,8 +21,9 @@ pub(super) fn emit_if_branch_call(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
     key: &str,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
-    vnode::emit_if_branch_element(cx, element, key)
+    vnode::emit_if_branch_element(cx, element, key, id)
 }
 
 pub(super) fn emit_for_op(

--- a/crates/vize_s1_to_s2/src/emit/patch.rs
+++ b/crates/vize_s1_to_s2/src/emit/patch.rs
@@ -7,7 +7,8 @@
 //! few position-local masks (`v-for`, `v-once`, `v-memo`).
 
 use alloc::vec::Vec as StdVec;
-
+use smallvec::SmallVec;
+use vize_davinci::id::NodeId;
 use vize_s0::String;
 use vize_s2::op::{Attribute, BindingOp, OnOp};
 
@@ -17,9 +18,54 @@ use super::props::{
     is_emitted_key_bind, static_bind_key,
 };
 
+pub(super) struct PatchFactsTable {
+    entries: SmallVec<[(NodeId, PatchFacts); 16]>,
+}
+
+impl PatchFactsTable {
+    pub(super) fn new() -> Self {
+        Self {
+            entries: SmallVec::new(),
+        }
+    }
+
+    fn materialize(&mut self, owner: Option<NodeId>, facts: PatchFacts) -> PatchFacts {
+        let Some(owner) = owner else {
+            return facts;
+        };
+        self.entries.push((owner, facts));
+        let (_, facts) = self.entries.pop().expect("patch fact was just pushed");
+        facts
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct PatchFacts {
     pub flag: i32,
     pub dynamic_props: StdVec<String>,
+}
+
+impl super::EmitCx<'_> {
+    pub(super) fn materialize_patch_facts<'a>(
+        &mut self,
+        owner: Option<NodeId>,
+        bindings: &[BindingOp<'a>],
+        is_component: bool,
+        if_key: Option<&str>,
+        for_item: bool,
+    ) -> PatchFacts {
+        let facts = binding_patch_facts(
+            bindings,
+            is_component,
+            if_key,
+            for_item,
+            self.is_ts,
+            &|name| self.reads_constant_binding_name(name),
+            &|on| super::on::caches_handler(self, on),
+            self.caches_handlers(),
+        );
+        self.patch_facts.materialize(owner, facts)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/vize_s1_to_s2/src/emit/run.rs
+++ b/crates/vize_s1_to_s2/src/emit/run.rs
@@ -64,6 +64,7 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
         scopes: &lowered.scopes,
         wrappers: &lowered.wrappers,
         for_wrappers: &lowered.for_wrappers,
+        patch_facts: super::patch::PatchFactsTable::new(),
         walk: PageWalk::new(),
         scope_names: StdVec::new(),
         if_branch_key: 0,

--- a/crates/vize_s1_to_s2/src/emit/tpl.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl.rs
@@ -81,7 +81,7 @@ fn unwrap_if(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<()
             register_unwrapped_if_child_props_hoist(cx, attributes, bindings, id)?;
             let previous = cx.template_if_branch_root;
             cx.template_if_branch_root = true;
-            let result = super::emit_if_branch_call(cx, element, key);
+            let result = super::emit_if_branch_call(cx, element, key, id);
             cx.template_if_branch_root = previous;
             result
         }

--- a/crates/vize_s1_to_s2/src/emit/vfor_item.rs
+++ b/crates/vize_s1_to_s2/src/emit/vfor_item.rs
@@ -25,14 +25,14 @@ pub(super) fn emit_element(
                         element,
                         false,
                         key,
-                        (false, None, PropHoistPosition::Nested),
+                        (false, id, PropHoistPosition::Nested),
                         true,
                         false,
                     )
                 })
             });
         }
-        emit_block(cx, element, key)
+        emit_block(cx, element, key, id)
     })
 }
 
@@ -40,6 +40,7 @@ fn emit_block(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
     key: Option<&str>,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     directive::wrap_element(cx, element, |cx| {
         cx.buf.use_open_block();
@@ -53,7 +54,7 @@ fn emit_block(
                 element,
                 true,
                 key,
-                (false, None, PropHoistPosition::Nested),
+                (false, id, PropHoistPosition::Nested),
                 true,
                 false,
             )

--- a/crates/vize_s1_to_s2/src/emit/vif.rs
+++ b/crates/vize_s1_to_s2/src/emit/vif.rs
@@ -243,9 +243,9 @@ fn branch_key_js(
 fn emit_branch(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<(), EmitError> {
     match branch.region.ops.as_slice() {
         [Op::Element(element)] => {
-            let _id = cx.walk.mint();
+            let id = cx.walk.mint();
             cx.walk.skip(element.bindings.len());
-            super::emit_if_branch_call(cx, element, key)
+            super::emit_if_branch_call(cx, element, key, id)
         }
         [Op::Component(component)] => {
             let _id = cx.walk.mint();

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -16,7 +16,7 @@ use super::children::children_need_text_flag;
 use super::directive;
 use super::flag::emit_patch_flag;
 use super::namespace;
-use super::patch::{apply_static_ref_patch, binding_patch_facts};
+use super::patch::apply_static_ref_patch;
 use super::props::{BindPropsOptions, admit_element_bindings, emit_bind_props};
 use super::props_dynamic::emit_dynamic_props;
 use super::props_static::PropHoistPosition;
@@ -165,13 +165,14 @@ pub(super) fn emit_if_branch_element(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
     key: &str,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     emit_block(
         cx,
         element,
         Some(key),
         false,
-        (true, None, PropHoistPosition::Nested),
+        (true, id, PropHoistPosition::Nested),
     )
 }
 
@@ -237,16 +238,7 @@ pub(super) fn emit_call(
             None
         };
     let hoist = hoisted_props.is_some();
-    let patch = binding_patch_facts(
-        &element.bindings,
-        false,
-        if_key,
-        for_item,
-        cx.is_ts,
-        &|name| cx.reads_constant_binding_name(name),
-        &|on| super::on::caches_handler(cx, on),
-        cx.caches_handlers(),
-    );
+    let patch = cx.materialize_patch_facts(id, &element.bindings, false, if_key, for_item);
     let text_flag = !once && !memo_block && children_need_text_flag(cx, &element.children);
     let mut flag = patch.flag;
     if text_flag {

--- a/davinci-road/plan/phase-3-records/p3-7.md
+++ b/davinci-road/plan/phase-3-records/p3-7.md
@@ -1,4 +1,4 @@
-# P3-7 - VDOM patch facts first slice
+# P3-7 - VDOM patch facts
 
 This slice starts replacing VDOM patch-flag inference with an explicit DOM
 realization fact surface while keeping shipped DOM output byte-identical.
@@ -12,19 +12,27 @@ realization, cached-handler state, component fallthrough props, and legacy
 patchless runtime expressions. Sending DOM through S3 here would either lose
 those inputs or re-derive them later, which is exactly the P3-7 problem.
 
-This does not close P3-7. The remaining work is to materialize the owner-keyed
-patch facts before VNode emission, connect them to the reactivity-lattice facts
-where binding metadata is available, and re-gate the DOM corpus.
+This does not close P3-7. The remaining work is to connect patch facts to the
+reactivity-lattice facts where binding metadata is available and re-gate the
+DOM corpus.
+
+The 2026-09-13 second slice materializes an owner-keyed `PatchFacts` side table
+inside the S2 DOM emitter before VNode call assembly. Native and component
+writers now read the table through `EmitCx::materialize_patch_facts`, while
+position-local masks (`v-for`, `v-once`, `v-memo`, text children, slots, and
+static refs) remain in the writer because their inputs are still emission
+context rather than binding facts.
 
 ## Decisions
 
-| subject       | decision                                                                                              |
-| ------------- | ----------------------------------------------------------------------------------------------------- |
-| Fact home     | `vize_s1_to_s2::emit::patch` owns `PatchFacts` instead of leaving the decision inside props emission. |
-| Compatibility | Existing `vize_atelier_core::codegen::patch_flag` remains only for compatibility fallback lanes.      |
-| Data carried  | `PatchFacts` carries the numeric flag plus the dynamic-prop key list in source order.                 |
-| Local masks   | `v-for`, `v-once`, `v-memo`, static refs, dynamic slots, and text-child flags stay at VNode position. |
-| Parity rule   | The broad patch-flag fixtures still compare S2 DOM output against the shipped compatibility lane.     |
+| subject       | decision                                                                                                                                                   |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fact home     | `vize_s1_to_s2::emit::patch` owns `PatchFacts` instead of leaving the decision inside props emission.                                                      |
+| Compatibility | Existing `vize_atelier_core::codegen::patch_flag` remains only for compatibility fallback lanes.                                                           |
+| Data carried  | `PatchFacts` carries the numeric flag plus the dynamic-prop key list in source order.                                                                      |
+| Table key     | `PatchFactsTable` is keyed by the owner `ui.element` / `ui.component` `NodeId` and populated before the patch flag or dynamic-props arguments are printed. |
+| Local masks   | `v-for`, `v-once`, `v-memo`, static refs, dynamic slots, and text-child flags stay at VNode position.                                                      |
+| Parity rule   | The broad patch-flag fixtures still compare S2 DOM output against the shipped compatibility lane.                                                          |
 
 ## Mechanical witnesses
 
@@ -33,11 +41,12 @@ where binding metadata is available, and re-gate the DOM corpus.
 - `cargo test -p vize_atelier_dom --test davinci_s2_recent_patch_flags -- --nocapture`
 - `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_static -- --nocapture`
 - `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_legacy --features legacy -- --nocapture`
+- `node --test tests/tooling/davinci-patch-facts-table.test.ts`
 
 ## Follow-up
 
-P3-7 still needs a pre-emission side table that keys `PatchFacts` by owner
-`NodeId`, plus DOM corpus TS-11 and patch-flag equivalence fixtures over the
-materialized table. Once S3 has typed binding payloads, this fact surface can
-move from S2 to the explicit S3 decision stream without changing the VNode
-writer again.
+P3-7 still needs reactivity-lattice inputs for binding constness where the
+metadata is available, plus DOM corpus TS-11 and patch-flag equivalence fixtures
+over the materialized table. Once S3 has typed binding payloads, this fact
+surface can move from S2 to the explicit S3 decision stream without changing
+the VNode writer again.

--- a/davinci-road/plan/phase-3.md
+++ b/davinci-road/plan/phase-3.md
@@ -12,7 +12,7 @@
 - [ ] P3-4 Lean reference semantics + differential runner
 - [x] P3-5 Impeto op reference doc (before optional passes)
 - [ ] P3-6 Vapor backend on S3
-- [ ] P3-7 VDOM patch flags from lattice facts
+- [ ] P3-7 VDOM patch flags from lattice facts _(slice 2 materializes the owner-keyed patch-facts table; see [record](./phase-3-records/p3-7.md))_
 - [ ] P3-8 SSR thin path
 - [ ] P3-9 S4 structured emitter + universal source maps _(slice 1 pins TS-31 source-map budgets before emitter migration; see [record](./phase-3-records/p3-9.md))_
 - [ ] P3-10 Try-measure-commit extraction _(slice 1 pins optimization budgets before extraction; see [record](./phase-3-records/p3-10.md))_
@@ -94,8 +94,11 @@ annotations if S3 detour measures badly — decide by TS-22). _Accept:_ corpus
 DOM byte-parity (TS-11 empty); patch-flag equivalence fixtures.
 _First slice 2026-09-13:_ see
 [P3-7 record](./phase-3-records/p3-7.md) for the S2→S4 annotation boundary and
-the initial `PatchFacts` split. The owner-keyed fact table and corpus gate
-remain before this task closes.
+the initial `PatchFacts` split.
+_Second slice 2026-09-13:_ `PatchFactsTable` is now owner-keyed by
+`ui.element` / `ui.component` `NodeId` and read by the VNode writers before
+printing patch flags or dynamic-props arguments. Reactivity-lattice integration
+and the DOM corpus gate remain before P3-7 closes.
 
 **P3-8 SSR thin path.** S2→S4 string-plan lowering reading partition facts;
 `vize_atelier_ssr` codegen re-targets. _Accept:_ SSR corpus byte-parity

--- a/tests/tooling/davinci-patch-facts-table.test.ts
+++ b/tests/tooling/davinci-patch-facts-table.test.ts
@@ -1,0 +1,55 @@
+// Davinci patch-facts table contract (plan/phase-3.md P3-7).
+//
+// P3-7 moves VDOM patch-flag decisions out of final call assembly. This keeps
+// the owner-keyed side table visible while the broad DOM parity suites pin the
+// emitted bytes.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const emitRoot = path.join(repoRoot, "crates", "vize_s1_to_s2", "src", "emit.rs");
+const runPath = path.join(repoRoot, "crates", "vize_s1_to_s2", "src", "emit", "run.rs");
+const patchPath = path.join(repoRoot, "crates", "vize_s1_to_s2", "src", "emit", "patch.rs");
+const vnodePath = path.join(repoRoot, "crates", "vize_s1_to_s2", "src", "emit", "vnode.rs");
+const componentPath = path.join(repoRoot, "crates", "vize_s1_to_s2", "src", "emit", "component.rs");
+const dispatchPath = path.join(repoRoot, "crates", "vize_s1_to_s2", "src", "emit", "dispatch.rs");
+
+function read(filePath: string): string {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+test("EmitCx carries an owner-keyed PatchFacts inline table", () => {
+  const emitSource = read(emitRoot);
+  const runSource = read(runPath);
+  const patchSource = read(patchPath);
+
+  assert.match(patchSource, /struct PatchFactsTable/);
+  assert.match(patchSource, /SmallVec<\[\(NodeId, PatchFacts\); 16\]>/);
+  assert.match(emitSource, /patch_facts: patch::PatchFactsTable,/);
+  assert.match(runSource, /patch_facts: super::patch::PatchFactsTable::new\(\),/);
+});
+
+test("VNode and component writers read materialized patch facts", () => {
+  const patchSource = read(patchPath);
+  const vnodeSource = read(vnodePath);
+  const componentSource = read(componentPath);
+
+  assert.match(patchSource, /fn materialize_patch_facts/);
+  assert.match(vnodeSource, /cx\.materialize_patch_facts\(id, &element\.bindings, false/);
+  assert.match(componentSource, /cx\.materialize_patch_facts\(id, &component\.bindings, true/);
+  assert.doesNotMatch(vnodeSource, /binding_patch_facts/);
+  assert.doesNotMatch(componentSource, /binding_patch_facts/);
+});
+
+test("if-branch native roots keep their owner id through dispatch", () => {
+  const dispatchSource = read(dispatchPath);
+  const vnodeSource = read(vnodePath);
+
+  assert.match(dispatchSource, /key: &str,\n    id: Option<NodeId>,/);
+  assert.match(dispatchSource, /vnode::emit_if_branch_element\(cx, element, key, id\)/);
+  assert.match(vnodeSource, /\(true, id, PropHoistPosition::Nested\)/);
+});


### PR DESCRIPTION
## Summary
- add an owner-keyed PatchFactsTable to the S2 DOM emitter context
- route native and component VNode writers through materialized patch facts
- preserve owner ids for if-branch native roots and v-for native items
- record the P3-7 second slice and add a tooling contract test

## Verification
- cargo fmt --check
- cargo check -p vize_s1_to_s2 --no-default-features
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_recent_patch_flags -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_static -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags_legacy --features legacy -- --nocapture
- node --test tests/tooling/davinci-patch-facts-table.test.ts
- node --test tests/tooling/davinci-patch-facts-table.test.ts tests/tooling/davinci-sourcemap-budgets.test.ts tests/tooling/davinci-optimization-budgets.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/6074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791852911&installation_model_id=422833&pr_number=6074&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F6074&signature=ef7dfe31f757cc71e7a5fe3ecabb4c52809301efaf1cd032025a992648c431ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Rendering Improvements**
  - Improved consistency when generating VDOM updates for conditional branches, components, and list items.
  - Patch information is now tracked per rendered element, supporting stable patch flags and dynamic-property handling across complex templates.
  - Preserved element identity through conditional and list rendering paths.

- **Tooling**
  - Added coverage for patch-information handling and element identity during VDOM generation.

- **Documentation**
  - Updated development records to document the VDOM patch-information workflow and remaining validation work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->